### PR TITLE
Remove Gaia GPS Default Layer

### DIFF
--- a/src/components/Coordinates.vue
+++ b/src/components/Coordinates.vue
@@ -371,7 +371,7 @@ export default {
         {
           name: 'Gaia GPS',
           url: () => {
-            return `https://www.gaiagps.com/map/?loc=14/${this.longitude}/${this.latitude}&layer=GaiaTopoRasterMeters`
+            return `https://www.gaiagps.com/map/?loc=14/${this.longitude}/${this.latitude}`
           }
         },
         {


### PR DESCRIPTION
I am a frequent Sotlas and Gaia GPS user. However, the current code overrides any layer setup the Gaia user might have. For example, my default map is the Gaia Topo, but in feet instead of meters. Right now, following the link from Sotlas to Gaia forces the Gaia Topo Meters layer, and I have to reset my layer choices after following the link. Removing the default will allow users to have their default layer selected. At least for me, this is a noticeable increase in usability. I have tested the URL format both as a logged in user in Gaia as well as while not logged in. As a logged in user it kept my selected layers unchanged, and as a non logged in user it appears to default to Gaia Topo Feet (not sure if this is regional or not).