### PR TITLE
Fix broken URL for OpenStreetMap (K6YK via SOTAData3)

### DIFF
--- a/src/components/Coordinates.vue
+++ b/src/components/Coordinates.vue
@@ -424,7 +424,7 @@ export default {
         {
           name: 'OpenStreetMap',
           url: () => {
-            return `https://www.openstreetmap.org/?mlat=${this.latitude}&mlon=${this.longitude}&zoom=16`
+            return `https://www.openstreetmap.org/#map=16/${this.latitude}/${this.longitude}`
           }
         },
         {

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -396,7 +396,7 @@ export default {
       if (summitCode.match(/^HB0?\//)) {
         return 'https://map.geo.admin.ch/?swisssearch=' + latitude + ',' + longitude
       } else {
-        return 'https://www.openstreetmap.org/?mlat=' + latitude + '&mlon=' + longitude + '&zoom=14'
+        return 'https://www.openstreetmap.org/#map=14/' + latitude + '/' + longitude + ''
       }
     },
     updateMapURL () {


### PR DESCRIPTION
OSM has updated its URLs as per https://reflector.sota.org.uk/t/open-street-map-button-on-summit-page-not-working-as-expected/37921/9