### PR TITLE
Localize map labels to browser language

### DIFF
--- a/src/mixins/mapstyle.js
+++ b/src/mixins/mapstyle.js
@@ -15,11 +15,17 @@ export default {
     this.updateMapTilerApiKey()
   },
   computed: {
+    mapLanguage () {
+      // Primary language subtag, e.g. 'ja' from 'ja-JP', 'en' from 'en-US'
+      return navigator.language.split('-')[0]
+    },
     mapStyle () {
       if (!this.mapTilerApiKey) {
         return null
       }
 
+      // Cloud styles: return UUID string so MapLibre GL fetches them internally.
+      // Language is applied post-load via applyLanguageToMap() in updateLayers().
       if (this.mapType === 'maptiler_outdoor') {
         if (this.$store.state.altitudeUnits === 'ft') {
           return 'dc9edd90-1320-4fa4-98ba-ad2d4efe5998'
@@ -34,7 +40,8 @@ export default {
         }
       }
 
-      let style = this.mapTypes[this.mapType].style
+      // Local styles: deep clone and patch (no post-load flash)
+      let style = JSON.parse(JSON.stringify(this.mapTypes[this.mapType].style))
 
       // Show/hide layers according to map options for initial render to save time
       style.layers.forEach(layer => {
@@ -55,7 +62,7 @@ export default {
       })
       style.glyphs = style.glyphs.replace('{key}', this.mapTilerApiKey)
 
-      // Patch units
+      // Patch units for SOTLAS summit labels
       if (this.$store.state.altitudeUnits === 'ft') {
         style.layers.forEach(layer => {
           if (layer.id === 'summits_names') {
@@ -66,7 +73,7 @@ export default {
         })
       }
 
-      return style
+      return this.applyLanguageToStyle(style)
     },
     mapType () {
       let mapType = this.$store.state.mapType
@@ -125,6 +132,13 @@ export default {
           }
         }
       })
+
+      // For cloud styles, apply language patches via setLayoutProperty
+      // (local styles are pre-patched in the mapStyle computed)
+      const isCloudStyle = (this.mapType === 'maptiler_outdoor' || this.mapType === 'maptiler_winter')
+      if (isCloudStyle) {
+        this.applyLanguageToMap(map)
+      }
 
       if (this.mapTypes[this.mapType].snow_depth) {
         if (this.mapOptions['snow_depth']) {
@@ -196,6 +210,105 @@ export default {
           }
         }
       }
+    },
+    patchStringTextField (textField, lang) {
+      // Bare 'name' or Mapbox-style placeholders '{name}', '{name:en}',
+      // '{name:latin}', '{name:nonlatin}', etc. → coalesce(name:XX, name).
+      // Without this branch, MapTiler layers that use '{name:en}' (Country/
+      // City/Continent/Ocean labels) leak English through.
+      if (textField === 'name' || /^\{name(:[\w-]+)?\}$/.test(textField)) {
+        return ['coalesce', ['get', `name:${lang}`], ['get', 'name']]
+      }
+      return undefined
+    },
+    applyLanguageToMap (map) {
+      const lang = this.mapLanguage
+      map.getStyle().layers.forEach(layer => {
+        if (!layer.layout || layer.layout['text-field'] === undefined) return
+        if (layer.id && layer.id.startsWith('summit')) return
+        if (layer.metadata && layer.metadata['sotlas-map-option']) return
+
+        const textField = layer.layout['text-field']
+        let patched
+        if (typeof textField === 'string') {
+          patched = this.patchStringTextField(textField, lang)
+        } else if (Array.isArray(textField)) {
+          patched = this.patchLanguageExpression(textField, lang)
+        }
+
+        if (patched !== undefined && patched !== textField) {
+          map.setLayoutProperty(layer.id, 'text-field', patched)
+        }
+      })
+    },
+    applyLanguageToStyle (style) {
+      const lang = this.mapLanguage
+      style.layers.forEach(layer => {
+        if (!layer.layout || layer.layout['text-field'] === undefined) return
+        if (layer.id && layer.id.startsWith('summit')) return
+        if (layer.metadata && layer.metadata['sotlas-map-option']) return
+
+        const textField = layer.layout['text-field']
+        if (typeof textField === 'string') {
+          const patched = this.patchStringTextField(textField, lang)
+          if (patched !== undefined) {
+            layer.layout['text-field'] = patched
+          }
+        } else if (Array.isArray(textField)) {
+          layer.layout['text-field'] = this.patchLanguageExpression(textField, lang)
+        }
+      })
+      return style
+    },
+    patchLanguageExpression (expr, lang) {
+      if (!Array.isArray(expr)) return expr
+
+      // ["get", "name"] or ["get", "name:latin"] or ["get", "name:nonlatin"]
+      // → ["coalesce", ["get", "name:XX"], ["get", "name"]]
+      if (expr[0] === 'get' && expr.length === 2) {
+        const field = expr[1]
+        if (field === 'name' || field === 'name:latin' || field === 'name:nonlatin') {
+          return ['coalesce', ['get', `name:${lang}`], ['get', 'name']]
+        }
+        return expr
+      }
+
+      const isNameGet = (e) => Array.isArray(e) && e.length === 2 && e[0] === 'get' &&
+        typeof e[1] === 'string' &&
+        (e[1] === 'name' || e[1] === 'name_int' || e[1].startsWith('name:'))
+
+      // ["concat", ...]: collapse when it joins >=2 name references with no
+      // structural non-name fields. Prevents the same name being rendered
+      // twice (e.g. latin + nonlatin → "東京\n東京").
+      if (expr[0] === 'concat') {
+        let nameRefs = 0
+        let otherNonStrings = 0
+        for (let i = 1; i < expr.length; i++) {
+          const arg = expr[i]
+          if (isNameGet(arg)) {
+            nameRefs++
+          } else if (Array.isArray(arg)) {
+            otherNonStrings++
+          }
+        }
+        if (nameRefs >= 2 && otherNonStrings === 0) {
+          return ['coalesce', ['get', `name:${lang}`], ['get', 'name']]
+        }
+      }
+
+      // ["coalesce", ...]: if any arg references a name field (anywhere in
+      // the list, not just first), replace the whole expression so the
+      // user's language wins over name_int / name:latin / etc.
+      if (expr[0] === 'coalesce') {
+        for (let i = 1; i < expr.length; i++) {
+          if (isNameGet(expr[i])) {
+            return ['coalesce', ['get', `name:${lang}`], ['get', 'name']]
+          }
+        }
+      }
+
+      // Recurse into nested expressions
+      return expr.map(item => Array.isArray(item) ? this.patchLanguageExpression(item, lang) : item)
     }
   },
   watch: {


### PR DESCRIPTION
## Summary

Map labels (countries, cities, oceans, etc.) on MapTiler base maps currently render in a mix of languages — typically English / Latin script, sometimes mixed with the local script. This PR makes those labels follow the user's primary browser language (`navigator.language`), so a Japanese user sees Japanese, a German user sees German, etc.

SOTLAS summit labels are intentionally **not** touched.

## How it works

- `mapLanguage` computed: returns the primary subtag (`'ja'` from `'ja-JP'`).
- **Local styles**: the style JSON is deep-cloned and patched inside the `mapStyle` computed, so the first paint already shows the right language (no flash).
- **MapTiler cloud styles** (UUID-based): patches are applied post-load via `setLayoutProperty()` in `updateLayers()`, since the style JSON isn't available locally.

Label patching covers the `text-field` shapes MapTiler uses:

- Bare strings: `name`, `{name}`, `{name:en}`, `{name:latin}`, … → `['coalesce', ['get', 'name:XX'], ['get', 'name']]`
- `['get', 'name' | 'name:latin' | 'name:nonlatin']`
- `['concat', …]` joining multiple name fields — collapsed to avoid duplicate rendering (e.g. `Tokyo\nTokyo`).
- `['coalesce', …]` containing any name reference — fully replaced so the user's language wins over `name_int` / `name:latin`.

Layers whose `id` starts with `summit` or that carry `metadata['sotlas-map-option']` are skipped.

## Test plan

- [x] Verified with `ja`, `en`, `de`, `fr` browser locales
- [x] Tested on both local styles and MapTiler cloud styles (outdoor / winter)
- [x] Summit labels unchanged
- [x] No duplicate name rendering on Japanese maps