### PR TITLE
fix: resolve vue-filepond's vue/dist/vue.esm import

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -55,7 +55,12 @@ export default defineConfig(async ({ mode }) => {
     ],
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, 'src')
+        '@': path.resolve(__dirname, 'src'),
+        // vue-filepond imports the extension-less 'vue/dist/vue.esm', which
+        // @vitejs/plugin-vue2's automatic 'vue' alias (prefix-matched) rewrites
+        // into a nonexistent path. Pin the exact id first so it resolves to
+        // the real file instead.
+        'vue/dist/vue.esm': 'vue/dist/vue.esm.js'
       },
     },
     optimizeDeps: {


### PR DESCRIPTION
@vitejs/plugin-vue2 automatically adds a `vue` resolve alias targeting
  `vue/dist/vue.runtime.esm.js`. Because Vite/rollup-alias prefix-matches
  plain string aliases (matching any id starting with `vue/`, not just the
  exact `vue` specifier), this also intercepts vue-filepond's extension-less
  import of `vue/dist/vue.esm`, rewriting it into the nonexistent path
  `vue/dist/vue.runtime.esm.js/dist/vue.esm` and breaking esbuild's
  dependency scan on `npm run dev`:
  
  ✘ [ERROR] Cannot read file: .../vue/dist/vue.runtime.esm.js/dist/vue.esm
      node_modules/vue-filepond/dist/vue-filepond.esm.js:11:16:
        11 │ import Vue from 'vue/dist/vue.esm';
  
  This fix pins an exact-match alias for `vue/dist/vue.esm` ahead of the
  plugin-vue2 one, so it resolves to the real `vue.esm.js` file instead.
  
  ### Verified
  - `npm run dev` starts cleanly, `vue-filepond.js` is pre-bundled correctly
    under `node_modules/.vite/deps/`, and the page responds with HTTP 200
  - `npm run lint` / `npm run build` pass
  
  ### Needs verification from a Pro environment
  I don't have a FontAwesome Pro subscription, so I couldn't test this on a
  clean `master` checkout (which requires `NPM_FONTAWESOME_TOKEN` to even
  run `npm install`, see #23). The packages involved
  (`@vitejs/plugin-vue2` 2.3.4, `vue-filepond` 6.0.3) are unchanged from
  current `master`, so the bug should reproduce identically — could someone
  with Pro access confirm `npm run dev` works as expected after this change?