### PR TITLE
Vue 3 migration - Phase 1 (core swap) and Phase 2 (Buefy 3 / Bulma 1.0)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     browser: true
   },
   extends: [
-    'plugin:vue/essential'
+    'plugin:vue/vue3-essential'
   ],
   rules: {
     'vue/multi-word-component-names': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "@maptiler/sdk": "^2.0.3",
         "@tmcw/togeojson": "^3.2.0",
         "axios": "^1.16.0",
-        "buefy": "^0.8.20",
-        "bulma": "^0.7.5",
+        "buefy": "^3.0.8",
+        "bulma": "^1.0.4",
         "cheap-ruler": "^2.5.1",
         "filepond": "^4.30.4",
         "filepond-plugin-file-validate-type": "^1.2.5",
@@ -2054,25 +2054,21 @@
       }
     },
     "node_modules/buefy": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.8.20.tgz",
-      "integrity": "sha512-pg8Cn0m9cjqp2/vaKT4VIfU8KIumuX/gAT1GtearXRs56+kKqAPx3j9O8cm9W6P4jPUCHajKX6H8AqD0ram2Bg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-3.0.8.tgz",
+      "integrity": "sha512-OUL7BXrq35xGxzTAJNEDzx7NzFD8+xaYTO3prWWe4XzaABcsHI1Omep1MWgA8Ntp16uz7L18+xP4YoRXfdICdw==",
       "license": "MIT",
       "dependencies": {
-        "bulma": "0.7.5"
-      },
-      "engines": {
-        "node": ">= 4.0.0",
-        "npm": ">= 3.0.0"
+        "bulma": "^1.0.4"
       },
       "peerDependencies": {
-        "vue": "^2.5.18"
+        "vue": "^3.0.0"
       }
     },
     "node_modules/bulma": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.5.tgz",
-      "integrity": "sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-1.0.4.tgz",
+      "integrity": "sha512-Ffb6YGXDiZYX3cqvSbHWqQ8+LkX6tVoTcZuVB3lm93sbAVXlO0D6QlOTMnV6g18gILpAXqkG2z9hf9z4hCjz2g==",
       "license": "MIT"
     },
     "node_modules/call-bind": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fortawesome/free-regular-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/vue-fontawesome": "^3.3.0",
-        "@gaviti/vue-turnstile": "^0.6.5",
+        "@gaviti/vue-turnstile": "^1.1.4",
         "@mapbox/mapbox-gl-draw": "github:manuelkasper/mapbox-gl-draw#sotlas2",
         "@maptiler/sdk": "^2.0.3",
         "@tmcw/togeojson": "^3.2.0",
@@ -699,39 +699,15 @@
       }
     },
     "node_modules/@gaviti/vue-turnstile": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@gaviti/vue-turnstile/-/vue-turnstile-0.6.5.tgz",
-      "integrity": "sha512-kS1SVFzDAFqiqrvEOPNQIRWfCi6tv9w/2aNBRdUa217PXjjSt35sofMqsz5LiU4xqyvnBMkp1f/aNUhNa8GxFg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@gaviti/vue-turnstile/-/vue-turnstile-1.1.4.tgz",
+      "integrity": "sha512-7REDoLx5iZoRZs8hQKXhBTGnXCb6XK/cbzlRNHHwM6j8+a8lujB5uvywpFJglQWWcBb9tCa+0yjcCsX6KK7BiA==",
       "license": "MIT",
       "dependencies": {
-        "vue": "^2.7.16"
+        "vue": "^3.5.13"
       },
       "engines": {
         "node": "^14.18.0 || >= 16.0.0"
-      }
-    },
-    "node_modules/@gaviti/vue-turnstile/node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
-      "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
-      }
-    },
-    "node_modules/@gaviti/vue-turnstile/node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
-        "csstype": "^3.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4557,22 +4533,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/proj4": {
       "version": "2.20.9",
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
@@ -5073,15 +5033,6 @@
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
       "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==",
       "license": "MIT"
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
         "@fortawesome/free-regular-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
-        "@fortawesome/vue-fontawesome": "^2.0.10",
+        "@fortawesome/vue-fontawesome": "^3.3.0",
         "@gaviti/vue-turnstile": "^0.6.5",
         "@mapbox/mapbox-gl-draw": "github:manuelkasper/mapbox-gl-draw#sotlas2",
         "@maptiler/sdk": "^2.0.3",
@@ -30,11 +30,12 @@
         "frappe-charts": "github:manuelkasper/frappe-charts#line-chart-y-axis-intervals-based-on-range",
         "haversine-distance": "^1.2.1",
         "maidenhead": "^1.0.7",
+        "mitt": "^3.0.1",
         "moment": "^2.29.4",
         "node-vincenty": "0.0.6",
         "photoswipe": "^4.1.3",
         "proj4": "^2.7.2",
-        "vue": "^2.7.16",
+        "vue": "^3.5.39",
         "vue-clipboard2": "^0.3.1",
         "vue-filepond": "^6.0.2",
         "vue-infinite-loading": "^2.4.5",
@@ -42,13 +43,13 @@
         "vue-mapbox": "github:manuelkasper/vue-mapbox#10cb772",
         "vue-match-media": "^1.0.3",
         "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
-        "vue-router": "^3.6.5",
+        "vue-router": "^4.6.4",
         "vue2-debounce": "^1.0.1",
         "vuedraggable": "^2.24.3",
-        "vuex": "^3.6.2"
+        "vuex": "^4.1.0"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue2": "^2.3.3",
+        "@vitejs/plugin-vue": "^6.0.7",
         "eslint": "^8.57.1",
         "eslint-plugin-vue": "^9.24.0",
         "sass": "^1.77.0",
@@ -690,13 +691,13 @@
       }
     },
     "node_modules/@fortawesome/vue-fontawesome": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.10.tgz",
-      "integrity": "sha512-OTETSXz+3ygD2OK2/vy82cmUBpuJqeOAg4gfnnv+f2Rir1tDIhQg026Q3NQxznq83ZLz8iNqGG9XJm26inpDeg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.3.0.tgz",
+      "integrity": "sha512-xwHZ4fdm5rRefKTV+AfACE4piO2RTBGp6pASGdZOdRpA3+FgHje5VZD9i3dQeTejSClhAg9kodXybfs9K9d2jg==",
       "license": "MIT",
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "vue": "~2"
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@gaviti/vue-turnstile": {
@@ -709,6 +710,30 @@
       },
       "engines": {
         "node": "^14.18.0 || >= 16.0.0"
+      }
+    },
+    "node_modules/@gaviti/vue-turnstile/node_modules/@vue/compiler-sfc": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
+      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      },
+      "optionalDependencies": {
+        "prettier": "^1.18.2 || ^2.0.0"
+      }
+    },
+    "node_modules/@gaviti/vue-turnstile/node_modules/vue": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
+      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
+      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-sfc": "2.7.16",
+        "csstype": "^3.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -748,6 +773,12 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@mapbox/extent": {
       "version": "0.4.0",
@@ -1267,6 +1298,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -1735,32 +1773,128 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@vitejs/plugin-vue2": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue2/-/plugin-vue2-2.3.4.tgz",
-      "integrity": "sha512-LgqtRRedJb1KdmgcllwGX0gtlPvOvtR6pITXmqxGwQhBZaAysg0Hd7wvj3sjCsj4+PENWsqS7O+ceYSOgJ+H9g==",
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+      "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
       "engines": {
-        "node": "^14.18.0 || >= 16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-        "vue": "^2.7.0-0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
       }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "vue": "3.5.39"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -2321,6 +2455,18 @@
       "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -2695,7 +2841,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -3946,6 +4091,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/maidenhead": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/maidenhead/-/maidenhead-1.0.7.tgz",
@@ -4062,6 +4216,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",
@@ -5415,14 +5575,24 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
-        "csstype": "^3.1.0"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-clipboard2": {
@@ -5522,10 +5692,19 @@
       "license": "MIT"
     },
     "node_modules/vue-router": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
-      "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==",
-      "license": "MIT"
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
     },
     "node_modules/vue-typed-emit": {
       "version": "1.2.0",
@@ -5571,12 +5750,15 @@
       }
     },
     "node_modules/vuex": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
+      "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
       "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      },
       "peerDependencies": {
-        "vue": "^2.0.0"
+        "vue": "^3.2.0"
       }
     },
     "node_modules/wgs84": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,11 +37,9 @@
         "proj4": "^2.7.2",
         "vue": "^3.5.39",
         "vue-clipboard2": "^0.3.1",
-        "vue-filepond": "^6.0.2",
+        "vue-filepond": "^8.0.0",
         "vue-infinite-loading": "^2.4.5",
-        "vue-lazy-youtube-video": "^2.3.0",
         "vue-mapbox": "github:manuelkasper/vue-mapbox#10cb772",
-        "vue-match-media": "^1.0.3",
         "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
         "vue-router": "^4.6.4",
         "vue2-debounce": "^1.0.1",
@@ -1759,12 +1757,6 @@
       "dependencies": {
         "@types/geojson": "*"
       }
-    },
-    "node_modules/@types/youtube": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.0.46.tgz",
-      "integrity": "sha512-Yf1Y4bDj/QIn8v+zdy0l7+OW6s1uoUvzVn5cGqPNCsL4iUW4gYUlIdQIRtH9NOHVgwZNLbVeeRDEn6N4RMq6Nw==",
-      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.2",
@@ -5398,6 +5390,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5630,13 +5623,13 @@
       }
     },
     "node_modules/vue-filepond": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vue-filepond/-/vue-filepond-6.0.3.tgz",
-      "integrity": "sha512-m0wArAdpgzOOs19bWA6zzYlHAb2aK+igPoKPZGrzpgKiiELPKW7XZ2OBDXzk7rhpFLkedujVrMqwjPyZfmQTTQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vue-filepond/-/vue-filepond-8.0.0.tgz",
+      "integrity": "sha512-FluypMbKJIcOfDi9gT34RQm7MkLDxnPbHQ4VrzNydAUTI1aMYVb1GhJGJjsz/iEtqAfR4V61BCN1TtWuXmTLsg==",
       "license": "MIT",
       "peerDependencies": {
         "filepond": ">=4.7.4 < 5.x",
-        "vue": ">=2.6.0 < 3.x"
+        "vue": ">=3 < 4"
       }
     },
     "node_modules/vue-infinite-loading": {
@@ -5648,20 +5641,6 @@
         "vue": "^2.6.10"
       }
     },
-    "node_modules/vue-lazy-youtube-video": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/vue-lazy-youtube-video/-/vue-lazy-youtube-video-2.4.0.tgz",
-      "integrity": "sha512-YRk/k5UbpwkTpL6lNkrgtXTnacUHjCcnKQlTemvURIU7K+ljg8Iz3b8RCwSxYExr6Boayizkj3+kM1rxYFylsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/youtube": "0.0.46",
-        "vue-typed-emit": "^1.0.0",
-        "vue-typed-refs": "^1.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^2.6.12"
-      }
-    },
     "node_modules/vue-mapbox": {
       "version": "0.4.1",
       "resolved": "git+ssh://git@github.com/manuelkasper/vue-mapbox.git#10cb77225740df4c635edb348f67df7bee32d7c8",
@@ -5671,19 +5650,6 @@
       "peerDependencies": {
         "@maptiler/sdk": "^2.0.1",
         "vue": "^2.6.6"
-      }
-    },
-    "node_modules/vue-match-media": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/vue-match-media/-/vue-match-media-1.0.3.tgz",
-      "integrity": "sha512-LVALG6n+uMJnSdackzykTKxiqL+YgmD+c8HeyC7NsYijOIbOfx5cKhP3F0+r6Gu18q4uv2pr4KAoXKeQQQQQ5w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "vue": "^2.3"
       }
     },
     "node_modules/vue-native-websocket": {
@@ -5704,31 +5670,6 @@
       },
       "peerDependencies": {
         "vue": "^3.5.0"
-      }
-    },
-    "node_modules/vue-typed-emit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vue-typed-emit/-/vue-typed-emit-1.2.0.tgz",
-      "integrity": "sha512-rfge6nOyQmx3c4KNb9hIFviRlyHWN/F4+SUCuVPzQ/tP1cseqC65Sh4CV2u2GznKazb48ymLXk1WmJdrGGjd9A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@vue/composition-api": "<=1.1.1",
-        "vue": "<3"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vue-typed-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-typed-refs/-/vue-typed-refs-1.0.0.tgz",
-      "integrity": "sha512-HrNHyt2SmvPzWqzl6yEb4dBc0yV7xgGb+BTF+XKokO6AwKWBcDd73ka/wCKvZ9KAnyL+4q3NOEQ8kPfyBWFBmg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=3.x",
-        "vue": ">=2.x"
       }
     },
     "node_modules/vue2-debounce": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "@maptiler/sdk": "^2.0.3",
     "@tmcw/togeojson": "^3.2.0",
     "axios": "^1.16.0",
-    "buefy": "^0.8.20",
-    "bulma": "^0.7.5",
+    "buefy": "^3.0.8",
+    "bulma": "^1.0.4",
     "cheap-ruler": "^2.5.1",
     "filepond": "^4.30.4",
     "filepond-plugin-file-validate-type": "^1.2.5",
@@ -59,9 +59,6 @@
     "vite-plugin-eslint": "^1.8.1"
   },
   "overrides": {
-    "buefy": {
-      "vue": "$vue"
-    },
     "vue-mapbox": {
       "vue": "$vue"
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/vue-fontawesome": "^3.3.0",
-    "@gaviti/vue-turnstile": "^0.6.5",
+    "@gaviti/vue-turnstile": "^1.1.4",
     "@mapbox/mapbox-gl-draw": "github:manuelkasper/mapbox-gl-draw#sotlas2",
     "@maptiler/sdk": "^2.0.3",
     "@tmcw/togeojson": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,9 @@
     "proj4": "^2.7.2",
     "vue": "^3.5.39",
     "vue-clipboard2": "^0.3.1",
-    "vue-filepond": "^6.0.2",
+    "vue-filepond": "^8.0.0",
     "vue-infinite-loading": "^2.4.5",
-    "vue-lazy-youtube-video": "^2.3.0",
     "vue-mapbox": "github:manuelkasper/vue-mapbox#10cb772",
-    "vue-match-media": "^1.0.3",
     "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
     "vue-router": "^4.6.4",
     "vue2-debounce": "^1.0.1",
@@ -67,16 +65,7 @@
     "vue-mapbox": {
       "vue": "$vue"
     },
-    "vue-filepond": {
-      "vue": "$vue"
-    },
     "vue-infinite-loading": {
-      "vue": "$vue"
-    },
-    "vue-match-media": {
-      "vue": "$vue"
-    },
-    "vue-lazy-youtube-video": {
       "vue": "$vue"
     },
     "vue2-debounce": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@fortawesome/vue-fontawesome": "^2.0.10",
+    "@fortawesome/vue-fontawesome": "^3.3.0",
     "@gaviti/vue-turnstile": "^0.6.5",
     "@mapbox/mapbox-gl-draw": "github:manuelkasper/mapbox-gl-draw#sotlas2",
     "@maptiler/sdk": "^2.0.3",
@@ -34,11 +34,12 @@
     "frappe-charts": "github:manuelkasper/frappe-charts#line-chart-y-axis-intervals-based-on-range",
     "haversine-distance": "^1.2.1",
     "maidenhead": "^1.0.7",
+    "mitt": "^3.0.1",
     "moment": "^2.29.4",
     "node-vincenty": "0.0.6",
     "photoswipe": "^4.1.3",
     "proj4": "^2.7.2",
-    "vue": "^2.7.16",
+    "vue": "^3.5.39",
     "vue-clipboard2": "^0.3.1",
     "vue-filepond": "^6.0.2",
     "vue-infinite-loading": "^2.4.5",
@@ -46,18 +47,41 @@
     "vue-mapbox": "github:manuelkasper/vue-mapbox#10cb772",
     "vue-match-media": "^1.0.3",
     "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
-    "vue-router": "^3.6.5",
+    "vue-router": "^4.6.4",
     "vue2-debounce": "^1.0.1",
     "vuedraggable": "^2.24.3",
-    "vuex": "^3.6.2"
+    "vuex": "^4.1.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue2": "^2.3.3",
+    "@vitejs/plugin-vue": "^6.0.7",
     "eslint": "^8.57.1",
     "eslint-plugin-vue": "^9.24.0",
     "sass": "^1.77.0",
     "vite": "^6.3.5",
     "vite-plugin-eslint": "^1.8.1"
+  },
+  "overrides": {
+    "buefy": {
+      "vue": "$vue"
+    },
+    "vue-mapbox": {
+      "vue": "$vue"
+    },
+    "vue-filepond": {
+      "vue": "$vue"
+    },
+    "vue-infinite-loading": {
+      "vue": "$vue"
+    },
+    "vue-match-media": {
+      "vue": "$vue"
+    },
+    "vue-lazy-youtube-video": {
+      "vue": "$vue"
+    },
+    "vue2-debounce": {
+      "vue": "$vue"
+    }
   },
   "browserslist": [
     "> 1%",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,11 @@
 <template>
   <div id="app">
     <NavBar />
-    <keep-alive include="Map">
-      <router-view />
-    </keep-alive>
+    <router-view v-slot="{ Component }">
+      <keep-alive include="Map">
+        <component :is="Component" />
+      </keep-alive>
+    </router-view>
     <vue-turnstile v-if="!authenticated" :site-key="siteKey" @verified="turnstileVerified" />
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -38,9 +38,8 @@ export default {
 </script>
 
 <style lang="scss">
-@import "bulma/bulma.sass";
+@use "bulma/versions/bulma-no-dark-mode";
 
-$link: $blue;
 $fp-enable-1x1: false;
 $fp-4x3-path: "../node_modules/flagpack/flags/4x3/";
 

--- a/src/components/ActivationCard.vue
+++ b/src/components/ActivationCard.vue
@@ -6,7 +6,7 @@
         {{ activation.qsos }} QSOs
         <font-awesome-icon :icon="['far', 'th-list']" class="faicon" />
       </div>
-      <div class="date">{{ activation.date | formatActivationDate }}</div>
+      <div class="date">{{ formatActivationDate(activation.date) }}</div>
       <div class="summit"><router-link :class="{ invalid: activation.summit.invalid }" :to="makeSummitLink(activation.summit.code)">{{ activation.summit.name }} ({{ activation.summit.code }})</router-link><font-awesome-icon v-if="hasOwnPhotos(activation.summit)" class="photos-icon" :icon="['far', 'images']" /><font-awesome-icon v-else-if="activation.summit.photoAuthors && activation.summit.photoAuthors.length > 0" class="photos-icon-others" :icon="['far', 'images']" /><AltitudeLabel :altitude="activation.summit.altitude" /><ActivationCount :activationCount="activation.summit.activationCount" /></div>
     </div>
   </div>

--- a/src/components/ActivationsList.vue
+++ b/src/components/ActivationsList.vue
@@ -6,36 +6,34 @@
       </template>
     </CardPagination>
     <b-table v-else class="auto-width" :narrowed="true" :paginated="true" :striped="true" :default-sort="['date', 'desc']" :per-page="perPage" :data="data" :row-class="rowClass">
-      <template v-slot="props">
-        <b-table-column field="date" label="Date" sortable>
-          {{ formatActivationDate(props.row.date) }}
-        </b-table-column>
-        <b-table-column field="summit.code" label="Summit" class="code" sortable>
-          <CountryFlag v-if="props.row.summit.isoCode" :country="props.row.summit.isoCode" class="flag" />
-          <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
-        </b-table-column>
-        <b-table-column field="summit.name" label="Name" class="name" sortable>
-          <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.name }}</router-link>
-          <font-awesome-icon v-if="hasOwnPhotos(props.row.summit)" class="photos-icon" :icon="['far', 'images']" />
-          <font-awesome-icon v-else-if="props.row.summit.photoAuthors && props.row.summit.photoAuthors.length > 0" class="photos-icon-others" :icon="['far', 'images']" />
-        </b-table-column>
-        <b-table-column field="summit.altitude" label="Altitude" class="altitude" sortable numeric>
-          <AltitudeLabel :altitude="props.row.summit.altitude" />
-        </b-table-column>
-        <b-table-column field="points" label="Points" sortable>
-          <SummitPointsLabel :points="props.row.points" :bonus="props.row.bonus" />
-        </b-table-column>
-        <b-table-column field="summit.activationCount" label="Activations" sortable numeric>
-          <ActivationCount :activationCount="props.row.summit.activationCount" />
-        </b-table-column>
-        <b-table-column field="callsignUsed" label="Callsign used" sortable>
-          {{ props.row.callsignUsed.toUpperCase() }}
-        </b-table-column>
-        <b-table-column field="qsos" label="QSOs" sortable numeric>
-          <span class="qsos" @click="openQsoList(props.row.id)">{{ props.row.qsos }}</span>
-          <font-awesome-icon :icon="['far', 'th-list']" class="faicon qsos" @click="openQsoList(props.row.id)" />
-        </b-table-column>
-      </template>
+      <b-table-column field="date" label="Date" sortable v-slot="props">
+        {{ formatActivationDate(props.row.date) }}
+      </b-table-column>
+      <b-table-column field="summit.code" label="Summit" class="code" sortable v-slot="props">
+        <CountryFlag v-if="props.row.summit.isoCode" :country="props.row.summit.isoCode" class="flag" />
+        <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
+      </b-table-column>
+      <b-table-column field="summit.name" label="Name" class="name" sortable v-slot="props">
+        <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.name }}</router-link>
+        <font-awesome-icon v-if="hasOwnPhotos(props.row.summit)" class="photos-icon" :icon="['far', 'images']" />
+        <font-awesome-icon v-else-if="props.row.summit.photoAuthors && props.row.summit.photoAuthors.length > 0" class="photos-icon-others" :icon="['far', 'images']" />
+      </b-table-column>
+      <b-table-column field="summit.altitude" label="Altitude" class="altitude" sortable numeric v-slot="props">
+        <AltitudeLabel :altitude="props.row.summit.altitude" />
+      </b-table-column>
+      <b-table-column field="points" label="Points" sortable v-slot="props">
+        <SummitPointsLabel :points="props.row.points" :bonus="props.row.bonus" />
+      </b-table-column>
+      <b-table-column field="summit.activationCount" label="Activations" sortable numeric v-slot="props">
+        <ActivationCount :activationCount="props.row.summit.activationCount" />
+      </b-table-column>
+      <b-table-column field="callsignUsed" label="Callsign used" sortable v-slot="props">
+        {{ props.row.callsignUsed.toUpperCase() }}
+      </b-table-column>
+      <b-table-column field="qsos" label="QSOs" sortable numeric v-slot="props">
+        <span class="qsos" @click="openQsoList(props.row.id)">{{ props.row.qsos }}</span>
+        <font-awesome-icon :icon="['far', 'th-list']" class="faicon qsos" @click="openQsoList(props.row.id)" />
+      </b-table-column>
       <template v-slot:bottom-left>
         <b-select v-model="perPage">
           <option v-for="option in perPageOptions" :key="option" :value="option">{{ option }} per page</option>

--- a/src/components/ActivationsList.vue
+++ b/src/components/ActivationsList.vue
@@ -6,9 +6,9 @@
       </template>
     </CardPagination>
     <b-table v-else class="auto-width" :narrowed="true" :paginated="true" :striped="true" :default-sort="['date', 'desc']" :per-page="perPage" :data="data" :row-class="rowClass">
-      <template slot-scope="props">
+      <template v-slot="props">
         <b-table-column field="date" label="Date" sortable>
-          {{ props.row.date | formatActivationDate }}
+          {{ formatActivationDate(props.row.date) }}
         </b-table-column>
         <b-table-column field="summit.code" label="Summit" class="code" sortable>
           <CountryFlag v-if="props.row.summit.isoCode" :country="props.row.summit.isoCode" class="flag" />

--- a/src/components/AlertsList.vue
+++ b/src/components/AlertsList.vue
@@ -4,7 +4,7 @@
       <template v-slot="{ row, prevRow }">
         <AlertCard :alert="row" :callsignLink="callsignLink" :showSummitInfo="showSummitInfo">
           <template v-if="needDateHeader(row, prevRow)" v-slot:header>
-            {{ row.dateActivated | formatAlertDate }}
+            {{ formatAlertDate(row.dateActivated) }}
           </template>
           <template v-if="canEditAlert(row)" v-slot:actions>
             <div class="actions">
@@ -17,8 +17,8 @@
       </template>
     </CardPagination>
     <p v-else-if="!$mq.desktop && cardAlerts.length === 0">No matching alerts found.</p>
-    <b-table v-else default-sort="dateActivated" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" :current-page.sync="curPage" :row-class="rowClass">
-      <template slot-scope="props">
+    <b-table v-else default-sort="dateActivated" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" v-model:current-page="curPage" :row-class="rowClass">
+      <template v-slot="props">
         <b-table-column field="dateActivated" class="timestamp" label="Date/Time" sortable>
           <span v-html="formatDateTimeRelative(props.row.dateActivated)" />
         </b-table-column>
@@ -54,7 +54,9 @@
               <span class="comments-text">{{ props.row.comments }} ({{ props.row.posterCallsign }})</span>
             </div>
             <b-dropdown v-if="canEditAlert(props.row)" class="actions" aria-role="list">
-              <b-button size="is-small" slot="trigger" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
+              <template v-slot:trigger>
+                <b-button size="is-small" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
+              </template>
 
               <b-dropdown-item aria-role="listitem" @click="editAlert(props.row)"><b-icon icon="edit" size="is-small" /><span class="dropdown-label">Edit</span></b-dropdown-item>
               <b-dropdown-item aria-role="listitem" @click="makeSpot(props.row)"><b-icon icon="plus" size="is-small" /><span class="dropdown-label">Spot</span></b-dropdown-item>
@@ -126,12 +128,10 @@ export default {
       default: true
     }
   },
-  filters: {
+  methods: {
     formatAlertDate (date) {
       return moment.utc(date).format('dddd, DD MMM YYYY')
-    }
-  },
-  methods: {
+    },
     needDateHeader (row, prevRow) {
       return (!prevRow || !moment.utc(prevRow.dateActivated).isSame(moment.utc(row.dateActivated), 'day'))
     },

--- a/src/components/AlertsList.vue
+++ b/src/components/AlertsList.vue
@@ -18,53 +18,51 @@
     </CardPagination>
     <p v-else-if="!$mq.desktop && cardAlerts.length === 0">No matching alerts found.</p>
     <b-table v-else default-sort="dateActivated" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" v-model:current-page="curPage" :row-class="rowClass">
-      <template v-slot="props">
-        <b-table-column field="dateActivated" class="timestamp" label="Date/Time" sortable>
-          <span v-html="formatDateTimeRelative(props.row.dateActivated)" />
-        </b-table-column>
-        <b-table-column v-if="showCallsign" field="activatorCallsign" label="Callsign" sortable>
-          <template v-if="callsignLink">
-            <router-link :to="makeActivatorLink(props.row.activatorCallsign)">{{ props.row.activatorCallsign }}</router-link>
-          </template>
-          <template v-else>
-            {{ props.row.activatorCallsign }}
-          </template>
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." class="nowrap" sortable>
-          <CountryFlag v-if="props.row.summit.isoCode && $mq.fullhd" :country="props.row.summit.isoCode" class="flag" />
-          <router-link v-if="props.row.summit.name" :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
-          <span v-else>{{ props.row.summit.code }}</span>
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.name" label="Summit Name" sortable>
-          <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.name }}</router-link>
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.altitude" label="Altitude" sortable numeric>
-          <template v-if="props.row.summit.altitude"><AltitudeLabel :altitude="props.row.summit.altitude" /></template>
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.points" label="Points" sortable numeric>
-          <SummitPointsLabel v-if="props.row.summit.points" :points="props.row.summit.points" />
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.activationCount" label="Act." sortable numeric>
-          <ActivationCount :activationCount="props.row.summit.activationCount" />
-        </b-table-column>
-        <b-table-column class="comments" label="Frequencies/Comments">
-          <div class="comments-cell">
-            <div>
-              {{ props.row.frequency }}<br />
-              <span class="comments-text">{{ props.row.comments }} ({{ props.row.posterCallsign }})</span>
-            </div>
-            <b-dropdown v-if="canEditAlert(props.row)" class="actions" aria-role="list">
-              <template v-slot:trigger>
-                <b-button size="is-small" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
-              </template>
-
-              <b-dropdown-item aria-role="listitem" @click="editAlert(props.row)"><b-icon icon="edit" size="is-small" /><span class="dropdown-label">Edit</span></b-dropdown-item>
-              <b-dropdown-item aria-role="listitem" @click="makeSpot(props.row)"><b-icon icon="plus" size="is-small" /><span class="dropdown-label">Spot</span></b-dropdown-item>
-              <b-dropdown-item aria-role="listitem" @click="deleteAlert(props.row)"><b-icon icon="trash-alt" type="is-danger" size="is-small" /><span class="has-text-danger dropdown-label">Delete</span></b-dropdown-item>
-            </b-dropdown>
+      <b-table-column field="dateActivated" class="timestamp" label="Date/Time" sortable v-slot="props">
+        <span v-html="formatDateTimeRelative(props.row.dateActivated)" />
+      </b-table-column>
+      <b-table-column v-if="showCallsign" field="activatorCallsign" label="Callsign" sortable v-slot="props">
+        <template v-if="callsignLink">
+          <router-link :to="makeActivatorLink(props.row.activatorCallsign)">{{ props.row.activatorCallsign }}</router-link>
+        </template>
+        <template v-else>
+          {{ props.row.activatorCallsign }}
+        </template>
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." class="nowrap" sortable v-slot="props">
+        <CountryFlag v-if="props.row.summit.isoCode && $mq.fullhd" :country="props.row.summit.isoCode" class="flag" />
+        <router-link v-if="props.row.summit.name" :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
+        <span v-else>{{ props.row.summit.code }}</span>
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.name" label="Summit Name" sortable v-slot="props">
+        <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.name }}</router-link>
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.altitude" label="Altitude" sortable numeric v-slot="props">
+        <template v-if="props.row.summit.altitude"><AltitudeLabel :altitude="props.row.summit.altitude" /></template>
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.points" label="Points" sortable numeric v-slot="props">
+        <SummitPointsLabel v-if="props.row.summit.points" :points="props.row.summit.points" />
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.activationCount" label="Act." sortable numeric v-slot="props">
+        <ActivationCount :activationCount="props.row.summit.activationCount" />
+      </b-table-column>
+      <b-table-column class="comments" label="Frequencies/Comments" v-slot="props">
+        <div class="comments-cell">
+          <div>
+            {{ props.row.frequency }}<br />
+            <span class="comments-text">{{ props.row.comments }} ({{ props.row.posterCallsign }})</span>
           </div>
-        </b-table-column>
-      </template>
+          <b-dropdown v-if="canEditAlert(props.row)" class="actions" aria-role="list">
+            <template v-slot:trigger>
+              <b-button size="is-small" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
+            </template>
+
+            <b-dropdown-item aria-role="listitem" @click="editAlert(props.row)"><b-icon icon="edit" size="is-small" /><span class="dropdown-label">Edit</span></b-dropdown-item>
+            <b-dropdown-item aria-role="listitem" @click="makeSpot(props.row)"><b-icon icon="plus" size="is-small" /><span class="dropdown-label">Spot</span></b-dropdown-item>
+            <b-dropdown-item aria-role="listitem" @click="deleteAlert(props.row)"><b-icon icon="trash-alt" type="is-danger" size="is-small" /><span class="has-text-danger dropdown-label">Delete</span></b-dropdown-item>
+          </b-dropdown>
+        </div>
+      </b-table-column>
       <template v-if="paginated" v-slot:bottom-left>
         <b-select v-model="perPage">
           <option v-for="option in perPageOptions" :key="option" :value="option">{{ option }} per page</option>

--- a/src/components/BasemapAtInfo.vue
+++ b/src/components/BasemapAtInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal :active.sync="active" :on-cancel="cancelInfo" :can-cancel="false">
+  <b-modal v-model:active="active" :on-cancel="cancelInfo" :can-cancel="false">
     <div class="box content">
       <div class="has-text-centered">
         <span class="fp at flag"></span>

--- a/src/components/CardPagination.vue
+++ b/src/components/CardPagination.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="card-list">
-    <b-pagination v-if="paginated && !infinite" :total="data.length" :current.sync="currentCardPage" :simple="true" size="is-small" :per-page="perPage" aria-next-label="Next page" aria-previous-label="Previous page" aria-page-label="Page" aria-current-label="Current page" />
+    <b-pagination v-if="paginated && !infinite" :total="data.length" v-model:current="currentCardPage" :simple="true" size="is-small" :per-page="perPage" aria-next-label="Next page" aria-previous-label="Previous page" aria-page-label="Page" aria-current-label="Current page" />
     <div v-for="(row, index) in pageData" :key="row[rowKey]">
       <slot :row="row" :prevRow="(index > 0 ? pageData[index-1] : null)"></slot>
     </div>
     <infinite-loading v-if="infinite" :identifier="infiniteIdentifier" @infinite="infiniteHandler">
-      <div slot="no-more"></div>
-      <div slot="no-results"></div>
+      <template v-slot:no-more><div></div></template>
+      <template v-slot:no-results><div></div></template>
     </infinite-loading>
   </div>
 </template>

--- a/src/components/ChasesList.vue
+++ b/src/components/ChasesList.vue
@@ -1,19 +1,17 @@
 <template>
   <b-table :narrowed="true" :paginated="true" :striped="true" :default-sort="['activationDate', 'desc']" :per-page="15" :data="data" :mobile-cards="false">
-    <template v-slot="props">
-      <b-table-column field="activationDate" label="Date" sortable>
-        {{ formatActivationDate(props.row.activationDate) }}
-      </b-table-column>
-      <b-table-column field="otherCallsign" label="Activator" sortable>
-        <router-link :to="makeActivatorLink(props.row.otherCallsign.toUpperCase())">{{ props.row.otherCallsign.toUpperCase() }}</router-link>
-      </b-table-column>
-      <b-table-column field="band" label="Band" :custom-sort="sortBand" sortable numeric>
-        {{ bandForDbFrequency(props.row.band) }}
-      </b-table-column>
-      <b-table-column field="mode" label="Mode" sortable>
-        <ModeLabel :mode="props.row.mode" />
-      </b-table-column>
-    </template>
+    <b-table-column field="activationDate" label="Date" sortable v-slot="props">
+      {{ formatActivationDate(props.row.activationDate) }}
+    </b-table-column>
+    <b-table-column field="otherCallsign" label="Activator" sortable v-slot="props">
+      <router-link :to="makeActivatorLink(props.row.otherCallsign.toUpperCase())">{{ props.row.otherCallsign.toUpperCase() }}</router-link>
+    </b-table-column>
+    <b-table-column field="band" label="Band" :custom-sort="sortBand" sortable numeric v-slot="props">
+      {{ bandForDbFrequency(props.row.band) }}
+    </b-table-column>
+    <b-table-column field="mode" label="Mode" sortable v-slot="props">
+      <ModeLabel :mode="props.row.mode" />
+    </b-table-column>
   </b-table>
 </template>
 

--- a/src/components/ChasesList.vue
+++ b/src/components/ChasesList.vue
@@ -1,8 +1,8 @@
 <template>
   <b-table :narrowed="true" :paginated="true" :striped="true" :default-sort="['activationDate', 'desc']" :per-page="15" :data="data" :mobile-cards="false">
-    <template slot-scope="props">
+    <template v-slot="props">
       <b-table-column field="activationDate" label="Date" sortable>
-        {{ props.row.activationDate | formatActivationDate }}
+        {{ formatActivationDate(props.row.activationDate) }}
       </b-table-column>
       <b-table-column field="otherCallsign" label="Activator" sortable>
         <router-link :to="makeActivatorLink(props.row.otherCallsign.toUpperCase())">{{ props.row.otherCallsign.toUpperCase() }}</router-link>

--- a/src/components/Coordinates.vue
+++ b/src/components/Coordinates.vue
@@ -5,9 +5,11 @@
       <b-field>
         <p class="control">
           <b-dropdown aria-role="list">
-            <b-button type="is-info" outlined size="is-small" icon-right="angle-down" slot="trigger">
-              Open
-            </b-button>
+            <template v-slot:trigger>
+              <b-button type="is-info" outlined size="is-small" icon-right="angle-down">
+                Open
+              </b-button>
+            </template>
 
             <b-dropdown-item v-for="action in filteredActions" :key="action.name" :has-link="true" aria-role="listitem"><a :href="action.url()" target="_blank">{{ action.name }}</a></b-dropdown-item>
           </b-dropdown>
@@ -17,7 +19,9 @@
         </p>
         <p v-if="haveAz" class="control">
           <b-dropdown>
-            <b-button slot="trigger" type="is-info" outlined size="is-small" icon-left="file-download" icon-right="angle-down">AZ</b-button>
+            <template v-slot:trigger>
+              <b-button type="is-info" outlined size="is-small" icon-left="file-download" icon-right="angle-down">AZ</b-button>
+            </template>
             <b-dropdown-item custom disabled><b>Activation zone</b></b-dropdown-item>
             <b-dropdown-item has-link><a :href="makeAzUrlForType('gpx')">GPX file</a></b-dropdown-item>
             <b-dropdown-item has-link><a :href="makeAzUrlForType('geojson')">GeoJSON file</a></b-dropdown-item>

--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="action-button download-button">
     <b-dropdown>
-      <b-button slot="trigger" type="is-info" size="is-small" outlined icon-left="file-download" icon-right="angle-down">Download</b-button>
+      <template v-slot:trigger>
+        <b-button type="is-info" size="is-small" outlined icon-left="file-download" icon-right="angle-down">Download</b-button>
+      </template>
       <b-dropdown-item has-link><a :href="makeUrlForType('gpx')">GPX file</a></b-dropdown-item>
       <b-dropdown-item has-link><a :href="makeUrlForType('kml')">KML file</a></b-dropdown-item>
       <b-dropdown-item has-link><a :href="makeUrlForType('geojson')">GeoJSON file</a></b-dropdown-item>

--- a/src/components/EditAlert.vue
+++ b/src/components/EditAlert.vue
@@ -34,7 +34,7 @@
       </b-field>
 
       <b-field label="Frequency-Mode(s)">
-        <b-taginput v-model="freqMode" ref="freqMode" autocomplete rounded :data="freqModeSuggestions" :confirm-key-codes="[9,13,32,188]" @typing="updateFreqModeSuggestions" @input="onFreqModeInput" @blur="onFreqModeBlur" @keydown="onFreqModeKeyDown" append-to-body />
+        <b-taginput v-model="freqMode" ref="freqMode" autocomplete rounded :data="freqModeSuggestions" :confirm-key-codes="[9,13,32,188]" @typing="updateFreqModeSuggestions" @update:model-value="onFreqModeInput" @blur="onFreqModeBlur" @keydown="onFreqModeKeyDown" append-to-body />
         <template v-slot:message>
           Format: <em>freq-mode, ...</em> (e.g. <em>7.030-cw, 14.250-ssb</em>)
         </template>

--- a/src/components/EditAlert.vue
+++ b/src/components/EditAlert.vue
@@ -34,8 +34,8 @@
       </b-field>
 
       <b-field label="Frequency-Mode(s)">
-        <b-taginput v-model="freqMode" ref="freqMode" autocomplete rounded :data="freqModeSuggestions" :confirm-key-codes="[9,13,32,188]" @typing="updateFreqModeSuggestions" @input="onFreqModeInput" @blur="onFreqModeBlur" @keydown.native="onFreqModeKeyDown" append-to-body />
-        <template slot="message">
+        <b-taginput v-model="freqMode" ref="freqMode" autocomplete rounded :data="freqModeSuggestions" :confirm-key-codes="[9,13,32,188]" @typing="updateFreqModeSuggestions" @input="onFreqModeInput" @blur="onFreqModeBlur" @keydown="onFreqModeKeyDown" append-to-body />
+        <template v-slot:message>
           Format: <em>freq-mode, ...</em> (e.g. <em>7.030-cw, 14.250-ssb</em>)
         </template>
       </b-field>

--- a/src/components/FilterInput.vue
+++ b/src/components/FilterInput.vue
@@ -1,12 +1,12 @@
 <template>
-  <b-input :value="value" ref="filter" :placeholder="placeholder" type="search" icon-pack="far" icon="search" :class="{ filter: true, invalid }" :size="size" rounded @input="updateValue" />
+  <b-input :model-value="modelValue" ref="filter" :placeholder="placeholder" type="search" icon-pack="far" icon="search" :class="{ filter: true, invalid }" :size="size" rounded @update:model-value="updateValue" />
 </template>
 
 <script>
 export default {
   name: 'FilterInput',
   props: {
-    value: String,
+    modelValue: String,
     size: String,
     placeholder: {
       type: String,
@@ -14,6 +14,7 @@ export default {
     },
     isRegex: Boolean
   },
+  emits: ['update:modelValue'],
   computed: {
     invalid () {
       if (!this.isRegex) {
@@ -21,7 +22,7 @@ export default {
       }
 
       try {
-        RegExp(this.value)
+        RegExp(this.modelValue)
         return false
       } catch (e) {
         return true
@@ -30,7 +31,7 @@ export default {
   },
   methods: {
     updateValue (value) {
-      this.$emit('input', value)
+      this.$emit('update:modelValue', value)
     },
     focus () {
       this.$refs.filter.focus()

--- a/src/components/FrequencyInput.vue
+++ b/src/components/FrequencyInput.vue
@@ -1,16 +1,17 @@
 <template>
-  <b-input class="freqinput" :value="value" :disabled="disabled" type="number" inputmode="decimal" placeholder="MHz" lang="en_EN" step="any" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required @input="updateValue" />
+  <b-input class="freqinput" :model-value="modelValue" :disabled="disabled" type="number" inputmode="decimal" placeholder="MHz" lang="en_EN" step="any" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required @update:model-value="updateValue" />
 </template>
 
 <script>
 export default {
   props: {
-    value: String,
+    modelValue: String,
     disabled: Boolean
   },
+  emits: ['update:modelValue'],
   methods: {
     updateValue (value) {
-      this.$emit('input', value)
+      this.$emit('update:modelValue', value)
     }
   }
 }

--- a/src/components/LazyYoutubeVideo.vue
+++ b/src/components/LazyYoutubeVideo.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="lazy-youtube" @click="playing = true">
+    <iframe v-if="playing" :src="src + '?autoplay=1'" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="y-video" />
+    <div v-else class="y-video-preview" :style="{ backgroundImage: 'url(' + previewImageUrl + ')' }">
+      <div class="y-video-play-button" />
+    </div>
+  </div>
+</template>
+
+<script>
+// Minimal Vue 3-native replacement for vue-lazy-youtube-video (Vue 2-only,
+// imports a removed Vue default export and can't run under Vue 3).
+export default {
+  name: 'LazyYoutubeVideo',
+  props: {
+    src: String,
+    previewImageSize: {
+      type: String,
+      default: 'hqdefault'
+    }
+  },
+  data () {
+    return {
+      playing: false
+    }
+  },
+  computed: {
+    videoId () {
+      let matches = /\/embed\/([\w-]+)/.exec(this.src)
+      return matches ? matches[1] : null
+    },
+    previewImageUrl () {
+      return 'https://i.ytimg.com/vi/' + this.videoId + '/' + this.previewImageSize + '.jpg'
+    }
+  }
+}
+</script>
+
+<style scoped>
+.lazy-youtube {
+  position: relative;
+  cursor: pointer;
+}
+.y-video {
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 16 / 9;
+}
+.y-video-preview {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.y-video-play-button {
+  width: 68px;
+  height: 48px;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 10px;
+  position: relative;
+}
+.y-video-play-button::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 54%;
+  transform: translate(-50%, -50%);
+  border-style: solid;
+  border-width: 12px 0 12px 20px;
+  border-color: transparent transparent transparent #fff;
+}
+</style>

--- a/src/components/LoggedActivationsList.vue
+++ b/src/components/LoggedActivationsList.vue
@@ -1,18 +1,16 @@
 <template>
   <div>
     <b-table :narrowed="true" :paginated="true" :striped="true" :default-sort="['activationDate', 'desc']" :per-page="15" :data="data" :mobile-cards="false">
-      <template v-slot="props">
-        <b-table-column field="activationDate" label="Date" sortable>
-          {{ formatActivationDate(props.row.activationDate) }}
-        </b-table-column>
-        <b-table-column field="ownCallsign" label="Activator" sortable>
-          <router-link :to="makeActivatorLinkUserId(props.row.userId)">{{ props.row.ownCallsign.toUpperCase() }}</router-link>
-        </b-table-column>
-        <b-table-column field="qsos" label="QSOs" sortable numeric>
-          <span class="qsos" @click="openQsoList(props.row.id)">{{ props.row.qsos }}</span>
-          <font-awesome-icon :icon="['far', 'th-list']" class="faicon qsos" @click="openQsoList(props.row.id)" />
-        </b-table-column>
-      </template>
+      <b-table-column field="activationDate" label="Date" sortable v-slot="props">
+        {{ formatActivationDate(props.row.activationDate) }}
+      </b-table-column>
+      <b-table-column field="ownCallsign" label="Activator" sortable v-slot="props">
+        <router-link :to="makeActivatorLinkUserId(props.row.userId)">{{ props.row.ownCallsign.toUpperCase() }}</router-link>
+      </b-table-column>
+      <b-table-column field="qsos" label="QSOs" sortable numeric v-slot="props">
+        <span class="qsos" @click="openQsoList(props.row.id)">{{ props.row.qsos }}</span>
+        <font-awesome-icon :icon="['far', 'th-list']" class="faicon qsos" @click="openQsoList(props.row.id)" />
+      </b-table-column>
     </b-table>
 
     <ModalQSOList :activationId="modalActivationId" @modalClosed="modalActivationId = null" />

--- a/src/components/LoggedActivationsList.vue
+++ b/src/components/LoggedActivationsList.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <b-table :narrowed="true" :paginated="true" :striped="true" :default-sort="['activationDate', 'desc']" :per-page="15" :data="data" :mobile-cards="false">
-      <template slot-scope="props">
+      <template v-slot="props">
         <b-table-column field="activationDate" label="Date" sortable>
-          {{ props.row.activationDate | formatActivationDate }}
+          {{ formatActivationDate(props.row.activationDate) }}
         </b-table-column>
         <b-table-column field="ownCallsign" label="Activator" sortable>
           <router-link :to="makeActivatorLinkUserId(props.row.userId)">{{ props.row.ownCallsign.toUpperCase() }}</router-link>

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -3,7 +3,7 @@
     <template #trigger="{ active }">
       <b-button class="callsign" :icon-right="active ? 'angle-up' : 'angle-down'" :label="$keycloak.tokenParsed.callsign ? $keycloak.tokenParsed.callsign : $keycloak.userName"></b-button>
     </template>
-    <b-dropdown-item v-if="$keycloak.tokenParsed.callsign" has-link><router-link :to="'/activators/' + $keycloak.tokenParsed.callsign" @click.native="$emit('linkClicked')">My activator page</router-link></b-dropdown-item>
+    <b-dropdown-item v-if="$keycloak.tokenParsed.callsign" has-link><router-link :to="'/activators/' + $keycloak.tokenParsed.callsign" @click="$emit('linkClicked')">My activator page</router-link></b-dropdown-item>
     <b-dropdown-item @click="doAccountManagement">Manage account</b-dropdown-item>
     <b-dropdown-item @click="doLogout">Logout</b-dropdown-item>
   </b-dropdown>

--- a/src/components/MapOptionsControl.vue
+++ b/src/components/MapOptionsControl.vue
@@ -13,66 +13,66 @@
       </div>
       <div class="map-option">
         <b-field grouped>
-          <b-checkbox v-model="mapOptions.regions" size="is-small" @input="setMapOption('regions', $event)">Regions</b-checkbox>
+          <b-checkbox v-model="mapOptions.regions" size="is-small" @update:model-value="setMapOption('regions', $event)">Regions</b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].contours" grouped>
-          <b-checkbox v-model="mapOptions.contours" size="is-small" @input="setMapOption('contours', $event)">Contour lines</b-checkbox>
+          <b-checkbox v-model="mapOptions.contours" size="is-small" @update:model-value="setMapOption('contours', $event)">Contour lines</b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].hillshading" grouped>
-          <b-checkbox v-model="mapOptions.hillshading" size="is-small" @input="setMapOption('hillshading', $event)">Hillshading</b-checkbox>
+          <b-checkbox v-model="mapOptions.hillshading" size="is-small" @update:model-value="setMapOption('hillshading', $event)">Hillshading</b-checkbox>
         </b-field>
         <b-field grouped>
-          <b-checkbox v-model="mapOptions.az" size="is-small" @input="setMapOption('az', $event)">
+          <b-checkbox v-model="mapOptions.az" size="is-small" @update:model-value="setMapOption('az', $event)">
             Activation zones
             <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click="showActivationZoneInfo" />
           </b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].slope_classes" grouped>
-          <b-checkbox v-model="mapOptions.slope_classes" size="is-small" @input="setMapOption('slope_classes', $event)">Slope classes</b-checkbox>
+          <b-checkbox v-model="mapOptions.slope_classes" size="is-small" @update:model-value="setMapOption('slope_classes', $event)">Slope classes</b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].snow_depth" grouped>
-          <b-checkbox v-model="mapOptions.snow_depth" size="is-small" @input="setMapOption('snow_depth', $event)">Snow depth
+          <b-checkbox v-model="mapOptions.snow_depth" size="is-small" @update:model-value="setMapOption('snow_depth', $event)">Snow depth
             <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click="showSnowDepthInfo" />
           </b-checkbox>
         </b-field>
       </div>
       <div class="map-option" v-if="mapTypes[mapType].difficulty">
         <b-field grouped>
-          <b-checkbox v-model="mapOptions.difficulty" size="is-small" @input="setMapOption('difficulty', $event)">
+          <b-checkbox v-model="mapOptions.difficulty" size="is-small" @update:model-value="setMapOption('difficulty', $event)">
             Hiking difficulty
             <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click="showHikingDifficultyInfo" />
           </b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].skiing" grouped>
-          <b-checkbox v-model="mapOptions.skiing" size="is-small" @input="setMapOption('skiing', $event)">Ski routes</b-checkbox>
+          <b-checkbox v-model="mapOptions.skiing" size="is-small" @update:model-value="setMapOption('skiing', $event)">Ski routes</b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].snowshoe" grouped>
-          <b-checkbox v-model="mapOptions.snowshoe" size="is-small" @input="setMapOption('snowshoe', $event)">Snowshoe routes</b-checkbox>
+          <b-checkbox v-model="mapOptions.snowshoe" size="is-small" @update:model-value="setMapOption('snowshoe', $event)">Snowshoe routes</b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].wildlife" grouped>
-          <b-checkbox v-model="mapOptions.wildlife" size="is-small" @input="setMapOption('wildlife', $event)">Wildlife reserves and areas</b-checkbox>
+          <b-checkbox v-model="mapOptions.wildlife" size="is-small" @update:model-value="setMapOption('wildlife', $event)">Wildlife reserves and areas</b-checkbox>
         </b-field>
       </div>
       <div class="map-option">
         <b-field grouped>
-          <b-checkbox v-model="mapOptions.spots" size="is-small" @input="setMapOption('spots', $event)">Recent spots</b-checkbox>
+          <b-checkbox v-model="mapOptions.spots" size="is-small" @update:model-value="setMapOption('spots', $event)">Recent spots</b-checkbox>
         </b-field>
         <b-field class="alert-days" grouped>
-          <b-checkbox v-model="mapOptions.alerts" size="is-small" @input="setMapOption('alerts', $event)">Alerts for next</b-checkbox>
-          <b-input v-model="mapOptions.alertDays" size="is-small" type="number" min="1" :disabled="!mapOptions.alerts" @input="setMapOption('alertDays', $event)" />
+          <b-checkbox v-model="mapOptions.alerts" size="is-small" @update:model-value="setMapOption('alerts', $event)">Alerts for next</b-checkbox>
+          <b-input v-model="mapOptions.alertDays" size="is-small" type="number" min="1" :disabled="!mapOptions.alerts" @update:model-value="setMapOption('alertDays', $event)" />
           <div class="tlabel">day(s)</div>
         </b-field>
         <b-field grouped>
-          <b-checkbox v-model="mapOptions.inactive" size="is-small" @input="setMapOption('inactive', $event)">Inactive summits</b-checkbox>
+          <b-checkbox v-model="mapOptions.inactive" size="is-small" @update:model-value="setMapOption('inactive', $event)">Inactive summits</b-checkbox>
         </b-field>
       </div>
       <div class="map-option">
         <b-field grouped>
-          <b-checkbox v-model="mapOptions.webcams" size="is-small" @input="setMapOption('webcams', $event)"><b-icon pack="fas" icon="camera-home" size="is-small" /> Webcams</b-checkbox>
+          <b-checkbox v-model="mapOptions.webcams" size="is-small" @update:model-value="setMapOption('webcams', $event)"><b-icon pack="fas" icon="camera-home" size="is-small" /> Webcams</b-checkbox>
         </b-field>
         <b-field grouped>
-          <b-radio v-model="mapOptions.webcamsType" size="is-small" native-value="daylight" :disabled="!mapOptions.webcams" @input="setMapOption('webcamsType', $event)">Daylight</b-radio>
-          <b-radio v-model="mapOptions.webcamsType" size="is-small" native-value="current" :disabled="!mapOptions.webcams" @input="setMapOption('webcamsType', $event)">Current</b-radio>
+          <b-radio v-model="mapOptions.webcamsType" size="is-small" native-value="daylight" :disabled="!mapOptions.webcams" @update:model-value="setMapOption('webcamsType', $event)">Daylight</b-radio>
+          <b-radio v-model="mapOptions.webcamsType" size="is-small" native-value="current" :disabled="!mapOptions.webcams" @update:model-value="setMapOption('webcamsType', $event)">Current</b-radio>
         </b-field>
       </div>
     </div>

--- a/src/components/MapOptionsControl.vue
+++ b/src/components/MapOptionsControl.vue
@@ -24,7 +24,7 @@
         <b-field grouped>
           <b-checkbox v-model="mapOptions.az" size="is-small" @input="setMapOption('az', $event)">
             Activation zones
-            <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click.native="showActivationZoneInfo" />
+            <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click="showActivationZoneInfo" />
           </b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].slope_classes" grouped>
@@ -32,7 +32,7 @@
         </b-field>
         <b-field v-if="mapTypes[mapType].snow_depth" grouped>
           <b-checkbox v-model="mapOptions.snow_depth" size="is-small" @input="setMapOption('snow_depth', $event)">Snow depth
-            <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click.native="showSnowDepthInfo" />
+            <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click="showSnowDepthInfo" />
           </b-checkbox>
         </b-field>
       </div>
@@ -40,7 +40,7 @@
         <b-field grouped>
           <b-checkbox v-model="mapOptions.difficulty" size="is-small" @input="setMapOption('difficulty', $event)">
             Hiking difficulty
-            <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click.native="showHikingDifficultyInfo" />
+            <b-icon pack="fas" icon="info-circle" size="is-small" type="is-info" @click="showHikingDifficultyInfo" />
           </b-checkbox>
         </b-field>
         <b-field v-if="mapTypes[mapType].skiing" grouped>

--- a/src/components/MapPhoto.vue
+++ b/src/components/MapPhoto.vue
@@ -1,13 +1,15 @@
 <template>
   <div>
     <MglMarker :coordinates="photoCoordinates">
-      <div slot="marker" class="marker-icon" @click="markerClicked">
-        <font-awesome-layers slot="marker" class="fa-2x fa-fw">
-          <font-awesome-icon v-if="photo.direction !== undefined" class="direction" :icon="['fas', 'location-arrow']" :transform="{ rotate: photo.direction - 45 }" :style="{ color: photo.highlight ? '#bb0000' : undefined, display: photo.highlight ? 'block' : undefined }" />
-          <font-awesome-icon icon="circle" :style="{ color: photo.highlight ? 'red' : undefined }" />
-          <font-awesome-icon :icon="['fas', 'camera']" transform="shrink-7" :style="{ color: 'white' }" />
-        </font-awesome-layers>
-      </div>
+      <template v-slot:marker>
+        <div class="marker-icon" @click="markerClicked">
+          <font-awesome-layers class="fa-2x fa-fw">
+            <font-awesome-icon v-if="photo.direction !== undefined" class="direction" :icon="['fas', 'location-arrow']" :transform="{ rotate: photo.direction - 45 }" :style="{ color: photo.highlight ? '#bb0000' : undefined, display: photo.highlight ? 'block' : undefined }" />
+            <font-awesome-icon icon="circle" :style="{ color: photo.highlight ? 'red' : undefined }" />
+            <font-awesome-icon :icon="['fas', 'camera']" transform="shrink-7" :style="{ color: 'white' }" />
+          </font-awesome-layers>
+        </div>
+      </template>
       <MglPopup :closeButton="false" @added="popupAdded">
         <div class="thumbwrapper">
           <img class="thumb" :src="photoSrc(photo, 'thumb')" @click="$emit('photoClicked', photo)" />

--- a/src/components/MapRoute.vue
+++ b/src/components/MapRoute.vue
@@ -3,22 +3,28 @@
     <MglGeojsonLayer v-if="trackSource" :sourceId="sourceId + '_trk'" :source="trackSource" :layerId="sourceId + '_trk'" :layer="trackLayer" before="summits_selected" />
     <MglGeojsonLayer v-if="waypointSource" :sourceId="sourceId + '_wpt'" :source="waypointSource" :layerId="sourceId + '_wpt'" :layer="waypointLayer" before="summits_selected" />
     <MglMarker v-if="startCoordinates" :coordinates="startCoordinates">
-      <font-awesome-layers slot="marker" class="fa-2x">
-        <font-awesome-icon icon="circle" :style="{ color: route.highlight ? '#ee0000' : '#0000ee' }" />
-        <font-awesome-icon :icon="['fas', 'hiking']" transform="shrink-6" :style="{ color: 'white' }" />
-      </font-awesome-layers>
+      <template v-slot:marker>
+        <font-awesome-layers class="fa-2x">
+          <font-awesome-icon icon="circle" :style="{ color: route.highlight ? '#ee0000' : '#0000ee' }" />
+          <font-awesome-icon :icon="['fas', 'hiking']" transform="shrink-6" :style="{ color: 'white' }" />
+        </font-awesome-layers>
+      </template>
     </MglMarker>
     <MglMarker v-if="parkingCoordinates" :coordinates="parkingCoordinates">
-      <font-awesome-layers slot="marker" class="fa-2x">
-        <font-awesome-icon icon="square" :style="{ color: 'white' }" />
-        <font-awesome-icon :icon="['fas', 'parking']" :style="{ color: route.highlight ? '#ee0000' : '#0000ee' }" />
-      </font-awesome-layers>
+      <template v-slot:marker>
+        <font-awesome-layers class="fa-2x">
+          <font-awesome-icon icon="square" :style="{ color: 'white' }" />
+          <font-awesome-icon :icon="['fas', 'parking']" :style="{ color: route.highlight ? '#ee0000' : '#0000ee' }" />
+        </font-awesome-layers>
+      </template>
     </MglMarker>
     <MglMarker v-if="publicTransportCoordinates" :coordinates="publicTransportCoordinates">
-      <font-awesome-layers slot="marker" class="fa-2x">
-        <font-awesome-icon icon="square" :style="{ color: route.highlight ? '#ee0000' : '#0000ee' }" />
-        <font-awesome-icon :icon="['fas', 'bus']" transform="shrink-6" :style="{ color: 'white' }" />
-      </font-awesome-layers>
+      <template v-slot:marker>
+        <font-awesome-layers class="fa-2x">
+          <font-awesome-icon icon="square" :style="{ color: route.highlight ? '#ee0000' : '#0000ee' }" />
+          <font-awesome-icon :icon="['fas', 'bus']" transform="shrink-6" :style="{ color: 'white' }" />
+        </font-awesome-layers>
+      </template>
     </MglMarker>
   </div>
 </template>

--- a/src/components/MapWebcam.vue
+++ b/src/components/MapWebcam.vue
@@ -1,13 +1,15 @@
 <template>
   <div>
     <MglMarker :coordinates="coordinates">
-      <div slot="marker" class="marker-icon" @click="markerClicked">
-        <font-awesome-layers slot="marker" class="fa-2x fa-fw">
-          <font-awesome-icon icon="circle" />
-          <font-awesome-icon :icon="['fas', 'camera-home']" transform="shrink-7 left-0.5" :style="{ color: 'white' }" />
-        </font-awesome-layers>
-        <div v-if="webcam.clusterSize > 1" class="clustersize">+{{ webcam.clusterSize - 1 }}</div>
-      </div>
+      <template v-slot:marker>
+        <div class="marker-icon" @click="markerClicked">
+          <font-awesome-layers class="fa-2x fa-fw">
+            <font-awesome-icon icon="circle" />
+            <font-awesome-icon :icon="['fas', 'camera-home']" transform="shrink-7 left-0.5" :style="{ color: 'white' }" />
+          </font-awesome-layers>
+          <div v-if="webcam.clusterSize > 1" class="clustersize">+{{ webcam.clusterSize - 1 }}</div>
+        </div>
+      </template>
       <MglPopup :closeButton="false" @added="popupAdded" @open="popupOpened" @close="popupClosed">
         <div :class="['thumbwrapper', size]">
           <a :href="thumbnailHref" target="_blank">

--- a/src/components/MapWebcams.vue
+++ b/src/components/MapWebcams.vue
@@ -162,7 +162,7 @@ export default {
       immediate: true
     }
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.cleanup()
   },
   data () {

--- a/src/components/ModalQSOList.vue
+++ b/src/components/ModalQSOList.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal :active.sync="modalActive" :can-cancel="['escape', 'outside']" has-modal-card>
+  <b-modal v-model:active="modalActive" :can-cancel="['escape', 'outside']" has-modal-card>
     <div class="modal-card">
       <header class="modal-card-head">
         <p class="modal-card-title"><span v-if="activationDetails"><router-link :to="makeActivatorLinkUserId(activationDetails.UserID)">{{ activationDetails.OwnCallsign }}</router-link> on <router-link :to="makeSummitLink(summitCode)">{{ activationDetails.Summit }}</router-link>, <span class="activation-date">{{ niceActivationDate }}</span></span></p>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-navbar wrapper-class="container" :class="{ 'search-focused': searchFocused }" :fixed-top="true" :close-on-click="false" :isActive.sync="burgerActive">
+  <b-navbar wrapper-class="container" :class="{ 'search-focused': searchFocused }" :fixed-top="true" :close-on-click="false" v-model:isActive="burgerActive">
     <template #brand>
       <b-navbar-item tag="router-link" to="/about">
         <img v-if="$mq.widescreen" src="../assets/sotlas.svg" alt="Logo">
@@ -18,12 +18,12 @@
       </b-navbar-item>
     </template>
     <template #end>
-      <b-navbar-item v-for="link in links" tag="router-link" :key="link.target" :to="link.target" :title="link.title" @click.native="closeBurger">
+      <b-navbar-item v-for="link in links" tag="router-link" :key="link.target" :to="link.target" :title="link.title" @click="closeBurger">
         <b-icon v-if="link.icon" :pack="link.iconPack" :icon="link.icon" />
         {{ link.text }}
       </b-navbar-item>
       <b-navbar-dropdown label="More">
-        <b-navbar-item v-for="link in moreLinks" tag="router-link" :key="link.target" :to="link.target" :title="link.title" @click.native="closeBurger">
+        <b-navbar-item v-for="link in moreLinks" tag="router-link" :key="link.target" :to="link.target" :title="link.title" @click="closeBurger">
           <b-icon v-if="link.icon" :pack="link.iconPack" :icon="link.icon" />{{ link.text }}
         </b-navbar-item>
       </b-navbar-dropdown>
@@ -62,10 +62,10 @@ export default {
   },
   watch: {
     burgerActive () {
-      EventBus.$emit(this.burgerActive ? 'navbarMenuOpened' : 'navbarMenuClosed')
+      EventBus.emit(this.burgerActive ? 'navbarMenuOpened' : 'navbarMenuClosed')
     }
   },
-  destroyed () {
+  unmounted () {
     clearInterval(this.clockInterval)
   },
   methods: {

--- a/src/components/NearbySummitsList.vue
+++ b/src/components/NearbySummitsList.vue
@@ -1,6 +1,8 @@
 <template>
   <b-dropdown ref="dropdown" aria-role="list" position="is-bottom-left" class="nearby-summits" append-to-body>
-    <b-button slot="trigger" icon-right="angle-down" :loading="loading" @click.stop="clickButton">Nearby</b-button>
+    <template v-slot:trigger>
+      <b-button icon-right="angle-down" :loading="loading" @click.stop="clickButton">Nearby</b-button>
+    </template>
     <b-dropdown-item v-for="summit in nearbySummits" :key="summit.code" aria-role="listitem" @click="clickSummit(summit)">
       <div class="summit-title"><div class="summit-name">{{ summit.name }}</div><div class="summit-alt"><AltitudeLabel :altitude="summit.altitude" /></div></div>
       <div class="summit-info"><div class="distance"><font-awesome-icon :icon="['far', 'arrows-h']" class="faicon" /><DistanceLabel :distance="summit.distance" :high-precision="true" /></div>{{ summit.code }}</div>

--- a/src/components/QSOList.vue
+++ b/src/components/QSOList.vue
@@ -1,23 +1,21 @@
 <template>
   <b-table class="auto-width" :narrowed="true" :striped="true" :data="data" :mobile-cards="false">
-    <template v-slot="props">
-      <b-table-column field="TimeOfDay" label="Time" class="nowrap" sortable>
-        {{ props.row.TimeOfDay }}
-      </b-table-column>
-      <b-table-column field="OtherCallsign" label="Callsign" class="nowrap" sortable>
-        <CountryFlag :country="isoCodeForCallsign(props.row.OtherCallsign.trim())" class="flag" />
-        <router-link :to="makeActivatorLink(props.row.OtherCallsign.trim())">{{ props.row.OtherCallsign.trim() }}</router-link>
-      </b-table-column>
-      <b-table-column field="Band" label="Band" :custom-sort="sortBand" class="nowrap" sortable numeric>
-        {{ bandForDbFrequency(props.row.Band) }}
-      </b-table-column>
-      <b-table-column field="Mode" label="Mode" class="mode nowrap" sortable>
-        <ModeLabel :mode="props.row.Mode" />
-      </b-table-column>
-      <b-table-column field="Notes" label="Notes" class="nowrap">
-        <span v-html="formatNotes(props.row.Notes)" />
-      </b-table-column>
-    </template>
+    <b-table-column field="TimeOfDay" label="Time" class="nowrap" sortable v-slot="props">
+      {{ props.row.TimeOfDay }}
+    </b-table-column>
+    <b-table-column field="OtherCallsign" label="Callsign" class="nowrap" sortable v-slot="props">
+      <CountryFlag :country="isoCodeForCallsign(props.row.OtherCallsign.trim())" class="flag" />
+      <router-link :to="makeActivatorLink(props.row.OtherCallsign.trim())">{{ props.row.OtherCallsign.trim() }}</router-link>
+    </b-table-column>
+    <b-table-column field="Band" label="Band" :custom-sort="sortBand" class="nowrap" sortable numeric v-slot="props">
+      {{ bandForDbFrequency(props.row.Band) }}
+    </b-table-column>
+    <b-table-column field="Mode" label="Mode" class="mode nowrap" sortable v-slot="props">
+      <ModeLabel :mode="props.row.Mode" />
+    </b-table-column>
+    <b-table-column field="Notes" label="Notes" class="nowrap" v-slot="props">
+      <span v-html="formatNotes(props.row.Notes)" />
+    </b-table-column>
   </b-table>
 </template>
 

--- a/src/components/QSOList.vue
+++ b/src/components/QSOList.vue
@@ -1,6 +1,6 @@
 <template>
   <b-table class="auto-width" :narrowed="true" :striped="true" :data="data" :mobile-cards="false">
-    <template slot-scope="props">
+    <template v-slot="props">
       <b-table-column field="TimeOfDay" label="Time" class="nowrap" sortable>
         {{ props.row.TimeOfDay }}
       </b-table-column>

--- a/src/components/RBNSpotCard.vue
+++ b/src/components/RBNSpotCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card">
     <div class="card-content">
-      <div class="freqmode">{{ spot.frequency | formatFrequency }} <ModeLabel :mode="spot.mode" /></div>
+      <div class="freqmode">{{ formatFrequency(spot.frequency) }} <ModeLabel :mode="spot.mode" /></div>
       <div class="time" v-html="formatTimeDay(spot.timeStamp)" />
       <div class="callsign">
         <CountryFlag :country="country(spot.callsign)" class="flag" />

--- a/src/components/RBNSpotsList.vue
+++ b/src/components/RBNSpotsList.vue
@@ -5,7 +5,7 @@
     </template>
   </CardPagination>
   <b-table v-else :default-sort="['timeStamp', 'desc']" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" :row-class="rowClass">
-    <template slot-scope="props">
+    <template v-slot="props">
       <b-table-column field="timeStamp" class="timestamp" label="Time" sortable>
         <span v-html="formatTimeDay(props.row.timeStamp)" />
       </b-table-column>
@@ -13,7 +13,7 @@
         <CountryFlag :country="country(props.row.callsign)" class="flag" /><template v-if="callsignLink"><router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link></template><template v-else>{{ props.row.callsign }}</template>
       </b-table-column>
       <b-table-column field="frequency" label="Frequency" sortable numeric>
-        {{ props.row.frequency | formatFrequency }}
+        {{ formatFrequency(props.row.frequency) }}
       </b-table-column>
       <b-table-column field="mode" label="Mode" sortable>
         <ModeLabel :mode="props.row.mode" />

--- a/src/components/RBNSpotsList.vue
+++ b/src/components/RBNSpotsList.vue
@@ -5,29 +5,27 @@
     </template>
   </CardPagination>
   <b-table v-else :default-sort="['timeStamp', 'desc']" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" :row-class="rowClass">
-    <template v-slot="props">
-      <b-table-column field="timeStamp" class="timestamp" label="Time" sortable>
-        <span v-html="formatTimeDay(props.row.timeStamp)" />
-      </b-table-column>
-      <b-table-column field="callsign" label="Callsign" sortable>
-        <CountryFlag :country="country(props.row.callsign)" class="flag" /><template v-if="callsignLink"><router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link></template><template v-else>{{ props.row.callsign }}</template>
-      </b-table-column>
-      <b-table-column field="frequency" label="Frequency" sortable numeric>
-        {{ formatFrequency(props.row.frequency) }}
-      </b-table-column>
-      <b-table-column field="mode" label="Mode" sortable>
-        <ModeLabel :mode="props.row.mode" />
-      </b-table-column>
-      <b-table-column field="snr" label="SNR" sortable numeric>
-        {{ props.row.snr }} dB
-      </b-table-column>
-      <b-table-column field="speed" label="Speed" sortable numeric>
-        {{ props.row.speed }} wpm
-      </b-table-column>
-      <b-table-column field="spotter" label="Spotter" sortable>
-        {{ props.row.spotter }}
-      </b-table-column>
-    </template>
+    <b-table-column field="timeStamp" class="timestamp" label="Time" sortable v-slot="props">
+      <span v-html="formatTimeDay(props.row.timeStamp)" />
+    </b-table-column>
+    <b-table-column field="callsign" label="Callsign" sortable v-slot="props">
+      <CountryFlag :country="country(props.row.callsign)" class="flag" /><template v-if="callsignLink"><router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link></template><template v-else>{{ props.row.callsign }}</template>
+    </b-table-column>
+    <b-table-column field="frequency" label="Frequency" sortable numeric v-slot="props">
+      {{ formatFrequency(props.row.frequency) }}
+    </b-table-column>
+    <b-table-column field="mode" label="Mode" sortable v-slot="props">
+      <ModeLabel :mode="props.row.mode" />
+    </b-table-column>
+    <b-table-column field="snr" label="SNR" sortable numeric v-slot="props">
+      {{ props.row.snr }} dB
+    </b-table-column>
+    <b-table-column field="speed" label="Speed" sortable numeric v-slot="props">
+      {{ props.row.speed }} wpm
+    </b-table-column>
+    <b-table-column field="spotter" label="Spotter" sortable v-slot="props">
+      {{ props.row.spotter }}
+    </b-table-column>
     <template v-if="paginated" v-slot:bottom-left>
       <b-select v-model="perPage">
         <option v-for="option in perPageOptions" :key="option" :value="option">{{ option }} per page</option>

--- a/src/components/ResourceList.vue
+++ b/src/components/ResourceList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="content">
     <ul class="resources">
-      <li v-for="resource in resources" :key="resource.id"><b-icon v-if="resource.icon" :icon="resource.icon" :pack="resource.iconPack" size="is-small" /><svgicon v-if="resource.svgicon" class="icon" :icon="resource.svgicon" color="#555" /><img v-if="resource.iconImg" class="icon" :src="resource.iconImg" />{{ resource.prefix ? resource.prefix + ': ' : '' }}<a :href="resource.url" target="_blank">{{ resource.title }}</a><span class="subdued author" v-if="resource.author">(by {{ resource.author }} on {{ resource.date | formatSubmittedDate }})</span><span v-if="resource.suffix" class="subdued details">{{ resource.suffix }}</span></li>
+      <li v-for="resource in resources" :key="resource.id"><b-icon v-if="resource.icon" :icon="resource.icon" :pack="resource.iconPack" size="is-small" /><svgicon v-if="resource.svgicon" class="icon" :icon="resource.svgicon" color="#555" /><img v-if="resource.iconImg" class="icon" :src="resource.iconImg" />{{ resource.prefix ? resource.prefix + ': ' : '' }}<a :href="resource.url" target="_blank">{{ resource.title }}</a><span class="subdued author" v-if="resource.author">(by {{ resource.author }} on {{ formatSubmittedDate(resource.date) }})</span><span v-if="resource.suffix" class="subdued details">{{ resource.suffix }}</span></li>
     </ul>
   </div>
 </template>
@@ -14,7 +14,7 @@ export default {
   props: {
     resources: Array
   },
-  filters: {
+  methods: {
     formatSubmittedDate (date) {
       return moment.unix(date).format('DD MMM YYYY')
     }

--- a/src/components/SearchField.vue
+++ b/src/components/SearchField.vue
@@ -20,14 +20,14 @@
       @select="onSelect"
       @focus="searchFocus"
       @blur="searchBlur"
-      @keydown.native.enter="doSearch"
+      @keydown.enter="doSearch"
     >
-      <template slot="empty">
+      <template v-slot:empty>
         <span v-if="isLoading">Searching...</span>
         <span v-else-if="showNoResults">No results found</span>
         <span v-else>Type some more to search...</span>
       </template>
-      <template slot="default" slot-scope="props">
+      <template v-slot:default="props">
         <span v-if="props.option.type === 'geoname'">
           <b-icon
             :icon="iconForFeatureClass(props.option.featureClass)"

--- a/src/components/SpotCard.vue
+++ b/src/components/SpotCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card">
     <div class="card-content">
-      <div class="freqmode"><span v-if="!spot.type || spot.type === 'NORMAL'">{{ spot.frequency | formatFrequency }} </span><ModeLabel :mode="spot.mode" :type="spot.type" /></div>
+      <div class="freqmode"><span v-if="!spot.type || spot.type === 'NORMAL'">{{ formatFrequency(spot.frequency) }} </span><ModeLabel :mode="spot.mode" :type="spot.type" /></div>
       <div class="time" v-html="formatTimeDay(spot.timeStamp)" />
       <div class="callsign">
         <template v-if="callsignLink">

--- a/src/components/SpotsList.vue
+++ b/src/components/SpotsList.vue
@@ -13,8 +13,8 @@
         </SpotCard>
       </template>
     </CardPagination>
-    <b-table v-else :default-sort="['timeStamp', 'desc']" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" :current-page.sync="curPage" :row-class="rowClass">
-      <template slot-scope="props">
+    <b-table v-else :default-sort="['timeStamp', 'desc']" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" v-model:current-page="curPage" :row-class="rowClass">
+      <template v-slot="props">
         <b-table-column field="timeStamp" class="timestamp" label="Time" sortable>
           <span v-html="formatTimeDay(props.row.timeStamp)" />
         </b-table-column>
@@ -27,7 +27,7 @@
           </template>
         </b-table-column>
         <b-table-column field="frequency" label="Frequency" sortable :custom-sort="sortFrequency" numeric>
-          <span v-if="!props.row.type || props.row.type === 'NORMAL'">{{ props.row.frequency | formatFrequency }}</span>
+          <span v-if="!props.row.type || props.row.type === 'NORMAL'">{{ formatFrequency(props.row.frequency) }}</span>
         </b-table-column>
         <b-table-column field="mode" label="Mode" sortable>
           <ModeLabel :mode="props.row.mode" :type="props.row.type" />
@@ -56,7 +56,9 @@
           <div class="comments-cell">
             <b-tooltip class="comments-tooltip" :label="props.row.comments" position="is-left" multilined :active="!$mq.fullhd"><div>{{ props.row.comments }}</div></b-tooltip>
             <b-dropdown v-if="canEditSpot(props.row)" class="actions" aria-role="list">
-              <b-button size="is-small" slot="trigger" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
+              <template v-slot:trigger>
+                <b-button size="is-small" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
+              </template>
 
               <b-dropdown-item aria-role="listitem" @click="editSpot(props.row)"><b-icon icon="edit" size="is-small" /><span class="dropdown-label">Edit</span></b-dropdown-item>
               <b-dropdown-item aria-role="listitem" @click="cloneSpot(props.row)"><b-icon icon="clone" size="is-small" /><span class="dropdown-label">Clone</span></b-dropdown-item>

--- a/src/components/SpotsList.vue
+++ b/src/components/SpotsList.vue
@@ -14,59 +14,57 @@
       </template>
     </CardPagination>
     <b-table v-else :default-sort="['timeStamp', 'desc']" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" v-model:current-page="curPage" :row-class="rowClass">
-      <template v-slot="props">
-        <b-table-column field="timeStamp" class="timestamp" label="Time" sortable>
-          <span v-html="formatTimeDay(props.row.timeStamp)" />
-        </b-table-column>
-        <b-table-column v-if="showCallsign" field="activatorCallsign" label="Callsign" sortable>
-          <template v-if="callsignLink">
-            <router-link :to="makeActivatorLink(props.row.activatorCallsign)">{{ props.row.activatorCallsign }}</router-link>
-          </template>
-          <template v-else>
-            {{ props.row.activatorCallsign }}
-          </template>
-        </b-table-column>
-        <b-table-column field="frequency" label="Frequency" sortable :custom-sort="sortFrequency" numeric>
-          <span v-if="!props.row.type || props.row.type === 'NORMAL'">{{ formatFrequency(props.row.frequency) }}</span>
-        </b-table-column>
-        <b-table-column field="mode" label="Mode" sortable>
-          <ModeLabel :mode="props.row.mode" :type="props.row.type" />
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." class="nowrap" sortable>
-          <CountryFlag v-if="props.row.summit.isoCode && $mq.fullhd" :country="props.row.summit.isoCode" class="flag" />
-          <router-link v-if="props.row.summit.name" :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
-          <span v-else>{{ props.row.summit.code }}</span>
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.name" label="Summit Name" sortable>
-          <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.name }}</router-link>
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.altitude" label="Altitude" sortable numeric>
-          <template v-if="props.row.summit.altitude"><AltitudeLabel :altitude="props.row.summit.altitude" /></template>
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.points" label="Points" sortable numeric>
-          <SummitPointsLabel v-if="props.row.summit.points" :points="props.row.summit.points" />
-        </b-table-column>
-        <b-table-column v-if="showSummitInfo" field="summit.activationCount" label="Act." sortable numeric>
-          <ActivationCount :activationCount="props.row.summit.activationCount" />
-        </b-table-column>
-        <b-table-column field="callsign" label="Posted By" sortable>
-          {{ props.row.callsign }}
-        </b-table-column>
-        <b-table-column field="comments" class="comments" label="Comments">
-          <div class="comments-cell">
-            <b-tooltip class="comments-tooltip" :label="props.row.comments" position="is-left" multilined :active="!$mq.fullhd"><div>{{ props.row.comments }}</div></b-tooltip>
-            <b-dropdown v-if="canEditSpot(props.row)" class="actions" aria-role="list">
-              <template v-slot:trigger>
-                <b-button size="is-small" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
-              </template>
+      <b-table-column field="timeStamp" class="timestamp" label="Time" sortable v-slot="props">
+        <span v-html="formatTimeDay(props.row.timeStamp)" />
+      </b-table-column>
+      <b-table-column v-if="showCallsign" field="activatorCallsign" label="Callsign" sortable v-slot="props">
+        <template v-if="callsignLink">
+          <router-link :to="makeActivatorLink(props.row.activatorCallsign)">{{ props.row.activatorCallsign }}</router-link>
+        </template>
+        <template v-else>
+          {{ props.row.activatorCallsign }}
+        </template>
+      </b-table-column>
+      <b-table-column field="frequency" label="Frequency" sortable :custom-sort="sortFrequency" numeric v-slot="props">
+        <span v-if="!props.row.type || props.row.type === 'NORMAL'">{{ formatFrequency(props.row.frequency) }}</span>
+      </b-table-column>
+      <b-table-column field="mode" label="Mode" sortable v-slot="props">
+        <ModeLabel :mode="props.row.mode" :type="props.row.type" />
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." class="nowrap" sortable v-slot="props">
+        <CountryFlag v-if="props.row.summit.isoCode && $mq.fullhd" :country="props.row.summit.isoCode" class="flag" />
+        <router-link v-if="props.row.summit.name" :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
+        <span v-else>{{ props.row.summit.code }}</span>
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.name" label="Summit Name" sortable v-slot="props">
+        <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.name }}</router-link>
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.altitude" label="Altitude" sortable numeric v-slot="props">
+        <template v-if="props.row.summit.altitude"><AltitudeLabel :altitude="props.row.summit.altitude" /></template>
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.points" label="Points" sortable numeric v-slot="props">
+        <SummitPointsLabel v-if="props.row.summit.points" :points="props.row.summit.points" />
+      </b-table-column>
+      <b-table-column v-if="showSummitInfo" field="summit.activationCount" label="Act." sortable numeric v-slot="props">
+        <ActivationCount :activationCount="props.row.summit.activationCount" />
+      </b-table-column>
+      <b-table-column field="callsign" label="Posted By" sortable v-slot="props">
+        {{ props.row.callsign }}
+      </b-table-column>
+      <b-table-column field="comments" class="comments" label="Comments" v-slot="props">
+        <div class="comments-cell">
+          <b-tooltip class="comments-tooltip" :label="props.row.comments" position="is-left" multilined :active="!$mq.fullhd"><div>{{ props.row.comments }}</div></b-tooltip>
+          <b-dropdown v-if="canEditSpot(props.row)" class="actions" aria-role="list">
+            <template v-slot:trigger>
+              <b-button size="is-small" icon-pack="fas" icon-right="caret-down" outlined>Actions</b-button>
+            </template>
 
-              <b-dropdown-item aria-role="listitem" @click="editSpot(props.row)"><b-icon icon="edit" size="is-small" /><span class="dropdown-label">Edit</span></b-dropdown-item>
-              <b-dropdown-item aria-role="listitem" @click="cloneSpot(props.row)"><b-icon icon="clone" size="is-small" /><span class="dropdown-label">Clone</span></b-dropdown-item>
-              <b-dropdown-item aria-role="listitem" @click="deleteSpot(props.row)"><b-icon icon="trash-alt" type="is-danger" size="is-small" /><span class="has-text-danger dropdown-label">Delete</span></b-dropdown-item>
-            </b-dropdown>
-          </div>
-        </b-table-column>
-      </template>
+            <b-dropdown-item aria-role="listitem" @click="editSpot(props.row)"><b-icon icon="edit" size="is-small" /><span class="dropdown-label">Edit</span></b-dropdown-item>
+            <b-dropdown-item aria-role="listitem" @click="cloneSpot(props.row)"><b-icon icon="clone" size="is-small" /><span class="dropdown-label">Clone</span></b-dropdown-item>
+            <b-dropdown-item aria-role="listitem" @click="deleteSpot(props.row)"><b-icon icon="trash-alt" type="is-danger" size="is-small" /><span class="has-text-danger dropdown-label">Delete</span></b-dropdown-item>
+          </b-dropdown>
+        </div>
+      </b-table-column>
       <template v-if="paginated" v-slot:bottom-left>
         <b-select v-model="perPage">
           <option v-for="option in perPageOptions" :key="option" :value="option">{{ option }} per page</option>

--- a/src/components/SummitActivations.vue
+++ b/src/components/SummitActivations.vue
@@ -58,14 +58,12 @@
               Modes
             </h4>
             <b-table :default-sort="['qsos', 'desc']" :narrowed="true" :striped="true" :data="modes" :mobile-cards="false">
-              <template v-slot="props">
-                <b-table-column field="mode" label="Mode" sortable>
-                  {{ props.row.mode.toUpperCase() }}
-                </b-table-column>
-                <b-table-column field="qsos" label="QSOs" sortable numeric>
-                  {{ props.row.qsos }}
-                </b-table-column>
-              </template>
+              <b-table-column field="mode" label="Mode" sortable v-slot="props">
+                {{ props.row.mode.toUpperCase() }}
+              </b-table-column>
+              <b-table-column field="qsos" label="QSOs" sortable numeric v-slot="props">
+                {{ props.row.qsos }}
+              </b-table-column>
             </b-table>
           </div>
         </div>

--- a/src/components/SummitActivations.vue
+++ b/src/components/SummitActivations.vue
@@ -58,7 +58,7 @@
               Modes
             </h4>
             <b-table :default-sort="['qsos', 'desc']" :narrowed="true" :striped="true" :data="modes" :mobile-cards="false">
-              <template slot-scope="props">
+              <template v-slot="props">
                 <b-table-column field="mode" label="Mode" sortable>
                   {{ props.row.mode.toUpperCase() }}
                 </b-table-column>

--- a/src/components/SummitList.vue
+++ b/src/components/SummitList.vue
@@ -1,6 +1,6 @@
 <template>
   <b-table :class="{ 'auto-width': autoWidth, summits: true }" default-sort="code" :narrowed="true" :striped="true" :data="data" :mobile-cards="false" :row-class="(row, index) => !row.isValid && 'is-invalid'">
-    <template slot-scope="props">
+    <template v-slot="props">
       <b-table-column field="code" label="Reference" class="nowrap" sortable>
         <router-link :to="makeSummitLink(props.row.code)">{{ props.row.code }}</router-link>
       </b-table-column>
@@ -21,7 +21,7 @@
       </b-table-column>
     </template>
 
-    <template v-if="myActivatedSummits" slot="footer">
+    <template v-if="myActivatedSummits" v-slot:footer>
       <ul class="legend">
         <li><font-awesome-icon :icon="['far', 'chevron-circle-down']" :class="['activation-icon', 'chased']" /> Chased</li>
         <li><font-awesome-icon :icon="['far', 'chevron-circle-up']" :class="['activation-icon', 'activated']" /> Activated</li>

--- a/src/components/SummitList.vue
+++ b/src/components/SummitList.vue
@@ -1,25 +1,23 @@
 <template>
   <b-table :class="{ 'auto-width': autoWidth, summits: true }" default-sort="code" :narrowed="true" :striped="true" :data="data" :mobile-cards="false" :row-class="(row, index) => !row.isValid && 'is-invalid'">
-    <template v-slot="props">
-      <b-table-column field="code" label="Reference" class="nowrap" sortable>
-        <router-link :to="makeSummitLink(props.row.code)">{{ props.row.code }}</router-link>
-      </b-table-column>
-      <b-table-column field="name" label="Name" class="summit-name" sortable>
-        <router-link :to="makeSummitLink(props.row.code)">{{ props.row.name }}</router-link>
-        <font-awesome-icon v-if="props.row.hasPhotos" class="photos-icon" :icon="['far', 'images']" />
-      </b-table-column>
-      <b-table-column field="altitude" :label="$mq.mobile ? 'Alt.' : 'Altitude'" class="nowrap" sortable numeric>
-        <AltitudeLabel :altitude="props.row.altitude" />
-      </b-table-column>
-      <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" class="nowrap" sortable>
-        <SummitPointsLabel :points="props.row.points" :bonus="$mq.mobile ? null : props.row.bonusPoints" class="points" />
-      </b-table-column>
-      <b-table-column field="activationCount" :label="$mq.mobile ? 'Act.' : 'Activations'" class="nowrap" sortable numeric>
-        {{ props.row.activationCount }}
-        <font-awesome-icon v-if="myActivatedSummits" :icon="activationIcon(props.row)" :class="activationIconClass(props.row)" :label="activationIconLabel(props.row)" :title="activationIconLabel(props.row)" />
-        <font-awesome-icon v-if="myActivatedSummitsThisYear" :icon="['far', 'calendar-check']" :class="calendarIconClass(props.row)" :label="calendarIconLabel(props.row)" :title="calendarIconLabel(props.row)" />
-      </b-table-column>
-    </template>
+    <b-table-column field="code" label="Reference" class="nowrap" sortable v-slot="props">
+      <router-link :to="makeSummitLink(props.row.code)">{{ props.row.code }}</router-link>
+    </b-table-column>
+    <b-table-column field="name" label="Name" class="summit-name" sortable v-slot="props">
+      <router-link :to="makeSummitLink(props.row.code)">{{ props.row.name }}</router-link>
+      <font-awesome-icon v-if="props.row.hasPhotos" class="photos-icon" :icon="['far', 'images']" />
+    </b-table-column>
+    <b-table-column field="altitude" :label="$mq.mobile ? 'Alt.' : 'Altitude'" class="nowrap" sortable numeric v-slot="props">
+      <AltitudeLabel :altitude="props.row.altitude" />
+    </b-table-column>
+    <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" class="nowrap" sortable v-slot="props">
+      <SummitPointsLabel :points="props.row.points" :bonus="$mq.mobile ? null : props.row.bonusPoints" class="points" />
+    </b-table-column>
+    <b-table-column field="activationCount" :label="$mq.mobile ? 'Act.' : 'Activations'" class="nowrap" sortable numeric v-slot="props">
+      {{ props.row.activationCount }}
+      <font-awesome-icon v-if="myActivatedSummits" :icon="activationIcon(props.row)" :class="activationIconClass(props.row)" :label="activationIconLabel(props.row)" :title="activationIconLabel(props.row)" />
+      <font-awesome-icon v-if="myActivatedSummitsThisYear" :icon="['far', 'calendar-check']" :class="calendarIconClass(props.row)" :label="calendarIconLabel(props.row)" :title="calendarIconLabel(props.row)" />
+    </b-table-column>
 
     <template v-if="myActivatedSummits" v-slot:footer>
       <ul class="legend">

--- a/src/components/SummitPhotos.vue
+++ b/src/components/SummitPhotos.vue
@@ -12,7 +12,7 @@
         </template>
       </SummitPhotosGroup>
     </div>
-    <b-modal :active.sync="isEditorActive" has-modal-card trap-focus aria-role="dialog" aria-modal>
+    <b-modal v-model:active="isEditorActive" has-modal-card trap-focus aria-role="dialog" aria-modal>
       <EditPhoto v-if="editingPhoto" :photo="editingPhoto" :summitCode="summit.code" @photoEdited="$emit('photoEdited')" />
     </b-modal>
   </div>

--- a/src/components/SummitPhotosGroup.vue
+++ b/src/components/SummitPhotosGroup.vue
@@ -109,14 +109,14 @@ export default {
     mouseoverPicture (picture) {
       this.photos.forEach(photo => {
         if (photo.filename === picture.filename && !photo.highlight) {
-          this.$set(photo, 'highlight', true)
+          photo.highlight = true
         } else if (photo.highlight) {
-          this.$set(photo, 'highlight', false)
+          photo.highlight = false
         }
       })
     },
     mouseleavePicture (picture) {
-      this.$set(this.photos.find(photo => photo.filename === picture.filename), 'highlight', false)
+      this.photos.find(photo => photo.filename === picture.filename).highlight = false
     },
     onEditPicture (picture) {
       this.$emit('editPhoto', picture)

--- a/src/components/SummitPopup.vue
+++ b/src/components/SummitPopup.vue
@@ -11,7 +11,7 @@
         <tr><th>Altitude</th><td><AltitudeLabel :altitude="summit.altitude" /></td></tr>
         <tr class="points"><th>Points</th><td><SummitPointsLabel :points="summit.points" :bonus="summit.bonusPoints" /></td></tr>
         <tr><th>Activations</th><td>{{ summit.activationCount }}</td></tr>
-        <tr v-if="summit.activationDate"><th>Last activation</th><td>{{ summit.activationDate | formatActivationDate }} (<router-link :to="makeActivatorLink(summit.activationCall)">{{ summit.activationCall }}</router-link>)</td></tr>
+        <tr v-if="summit.activationDate"><th>Last activation</th><td>{{ formatActivationDate(summit.activationDate) }} (<router-link :to="makeActivatorLink(summit.activationCall)">{{ summit.activationCall }}</router-link>)</td></tr>
         <tr v-if="lastSpot"><th>Last spot</th><td><span v-html="formatTimeDay(lastSpot.timeStamp)" />: <router-link :to="makeActivatorLink(lastSpot.activatorCallsign)">{{ lastSpot.activatorCallsign }}</router-link><span v-if="lastSpot.frequency">, {{ lastSpot.frequency }}</span> <ModeLabel :mode="lastSpot.mode" :type="lastSpot.type" /></td></tr>
         <tr v-if="nextAlert" class="nextAlert"><th>Next alert</th><td><span v-html="formatDateTimeRelative(nextAlert.dateActivated)" />: <router-link :to="makeActivatorLink(nextAlert.activatorCallsign)">{{ nextAlert.activatorCallsign }}</router-link><div v-if="nextAlert.frequency" class="alertFrequencies">{{ nextAlert.frequency }}</div><div v-if="nextAlert.comments" class="alertComments">{{ nextAlert.comments }}</div></td></tr>
       </table>

--- a/src/components/SummitRoutes.vue
+++ b/src/components/SummitRoutes.vue
@@ -1,19 +1,17 @@
 <template>
   <b-table ref="routesTable" :data="routes" :narrowed="true" :striped="true" detailed @details-open="detailsOpen" @details-close="detailsClose">
-    <template v-slot="props">
-      <b-table-column field="title" label="Title" :sortable="routes.length > 1">
-        <span><a @click="toggle(props.row)"><strong>{{ props.row.title }}</strong></a> <RouteAttributes class="route-attributes" :route="props.row" :summit="summit" @mapReposition="coordinates => $emit('mapReposition', coordinates)" /></span>
-      </b-table-column>
-      <b-table-column field="ascent" label="Ascent" numeric :sortable="routes.length > 1">
-        <span><AltitudeLabel v-if="props.row.ascent" :altitude="props.row.ascent" /></span>
-      </b-table-column>
-      <b-table-column field="descent" label="Descent" numeric :sortable="routes.length > 1">
-        <span><AltitudeLabel v-if="props.row.descent" :altitude="props.row.descent" /></span>
-      </b-table-column>
-      <b-table-column field="distance" label="Distance" numeric :sortable="routes.length > 1">
-        <DistanceLabel v-if="props.row.distance" :distance="props.row.distance" />
-      </b-table-column>
-    </template>
+    <b-table-column field="title" label="Title" :sortable="routes.length > 1" v-slot="props">
+      <span><a @click="toggle(props.row)"><strong>{{ props.row.title }}</strong></a> <RouteAttributes class="route-attributes" :route="props.row" :summit="summit" @mapReposition="coordinates => $emit('mapReposition', coordinates)" /></span>
+    </b-table-column>
+    <b-table-column field="ascent" label="Ascent" numeric :sortable="routes.length > 1" v-slot="props">
+      <span><AltitudeLabel v-if="props.row.ascent" :altitude="props.row.ascent" /></span>
+    </b-table-column>
+    <b-table-column field="descent" label="Descent" numeric :sortable="routes.length > 1" v-slot="props">
+      <span><AltitudeLabel v-if="props.row.descent" :altitude="props.row.descent" /></span>
+    </b-table-column>
+    <b-table-column field="distance" label="Distance" numeric :sortable="routes.length > 1" v-slot="props">
+      <DistanceLabel v-if="props.row.distance" :distance="props.row.distance" />
+    </b-table-column>
 
     <template v-slot:detail="props">
       <div v-if="(props.row.parking && props.row.parking.description) || (props.row.publicTransport && props.row.publicTransport.description)" class="add-description-wrapper">

--- a/src/components/SummitRoutes.vue
+++ b/src/components/SummitRoutes.vue
@@ -1,6 +1,6 @@
 <template>
   <b-table ref="routesTable" :data="routes" :narrowed="true" :striped="true" detailed @details-open="detailsOpen" @details-close="detailsClose">
-    <template slot-scope="props">
+    <template v-slot="props">
       <b-table-column field="title" label="Title" :sortable="routes.length > 1">
         <span><a @click="toggle(props.row)"><strong>{{ props.row.title }}</strong></a> <RouteAttributes class="route-attributes" :route="props.row" :summit="summit" @mapReposition="coordinates => $emit('mapReposition', coordinates)" /></span>
       </b-table-column>
@@ -15,7 +15,7 @@
       </b-table-column>
     </template>
 
-    <template slot="detail" slot-scope="props">
+    <template v-slot:detail="props">
       <div v-if="(props.row.parking && props.row.parking.description) || (props.row.publicTransport && props.row.publicTransport.description)" class="add-description-wrapper">
         <div v-if="props.row.parking && props.row.parking.description" class="add-description">
           <font-awesome-icon class="fa-icon clickable" :icon="['fas', 'parking']" @click="$emit('mapReposition', props.row.parking.coordinates)" />
@@ -30,7 +30,7 @@
         </div>
       </div>
       <article class="routeDescr" v-html="linkifyCoordinates(props.row.htmlDescription ? props.row.htmlDescription : props.row.description)" />
-      <div class="author">Posted on {{ props.row.postedDate | formatActivationDate }} by {{ props.row.author }}</div>
+      <div class="author">Posted on {{ formatActivationDate(props.row.postedDate) }} by {{ props.row.author }}</div>
       <div class="track-download" v-if="props.row.track">
         <TrackLink :route="props.row" :summit="summit"><font-awesome-icon :icon="['far', 'file-download']" class="fa-icon" /> Download track (.gpx)</TrackLink>
       </div>

--- a/src/components/SummitVideosGroup.vue
+++ b/src/components/SummitVideosGroup.vue
@@ -9,8 +9,7 @@
 </template>
 
 <script>
-import LazyYoutubeVideo from 'vue-lazy-youtube-video'
-import 'vue-lazy-youtube-video/dist/style.css'
+import LazyYoutubeVideo from './LazyYoutubeVideo.vue'
 
 export default {
   name: 'SummitVideosGroup',

--- a/src/components/SwisstopoInfo.vue
+++ b/src/components/SwisstopoInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal :active.sync="active" :on-cancel="cancelInfo" :can-cancel="false">
+  <b-modal v-model:active="active" :on-cancel="cancelInfo" :can-cancel="false">
     <div class="box content">
       <div class="has-text-centered">
         <span class="fp ch flag"></span>

--- a/src/components/TrackLink.vue
+++ b/src/components/TrackLink.vue
@@ -73,7 +73,7 @@ export default {
       }
     }
   },
-  destroyed () {
+  unmounted () {
     if (this.objectUrl) {
       URL.revokeObjectURL(this.objectUrl)
       this.objectUrl = null

--- a/src/event-bus.js
+++ b/src/event-bus.js
@@ -1,5 +1,5 @@
-import Vue from 'vue'
+import mitt from 'mitt'
 
-const EventBus = new Vue()
+const EventBus = mitt()
 
 export default EventBus

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
-import Buefy from 'buefy'
+// import Buefy from 'buefy'
 // import vueDebounce from 'vue2-debounce'
 // import VueClipboard from 'vue-clipboard2'
 import MatchMedia from './matchmedia'
@@ -43,10 +43,14 @@ app.component('font-awesome-layers', FontAwesomeLayers)
 // are temporarily unavailable, silently no-op in templates) until replaced (Phase 4).
 // app.use(vueDebounce)
 // app.use(VueClipboard)
-app.use(Buefy, {
-  defaultIconComponent: 'font-awesome-icon',
-  defaultIconPack: 'far'
-})
+// Buefy 0.8's install() writes to Vue.prototype (Vue 2-only; Vue 3 apps have no
+// .prototype), so app.use(Buefy, ...) throws immediately and prevents any page
+// from rendering. Disabled until the Buefy 3 upgrade (Phase 2); <b-*> components
+// render as unstyled/unrecognized elements in the meantime.
+// app.use(Buefy, {
+//   defaultIconComponent: 'font-awesome-icon',
+//   defaultIconPack: 'far'
+// })
 app.use(MatchMedia)
 app.use(store)
 app.use(router)
@@ -95,7 +99,8 @@ axios.interceptors.response.use(response => {
   if (!error.config.ignoreError && (!lastError || new Date().getTime() - lastError > 9000) && (!error.response || error.response.status !== 404) && mounted) {
     // SnackbarProgrammatic.open doesn't work with Webpack 5
     // See https://github.com/buefy/buefy/issues/2299
-    app.config.globalProperties.$buefy.snackbar.open({
+    // $buefy is unavailable until the Buefy 3 upgrade (Phase 2, see app.use(Buefy) above).
+    app.config.globalProperties.$buefy?.snackbar.open({
       duration: 9000,
       message: 'Network or server error while loading data, try again later',
       type: 'is-danger',

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
-// import Buefy from 'buefy'
+import Buefy from 'buefy'
 // import vueDebounce from 'vue2-debounce'
 // import VueClipboard from 'vue-clipboard2'
 import MatchMedia from './matchmedia'
@@ -43,14 +43,10 @@ app.component('font-awesome-layers', FontAwesomeLayers)
 // are temporarily unavailable, silently no-op in templates) until replaced (Phase 4).
 // app.use(vueDebounce)
 // app.use(VueClipboard)
-// Buefy 0.8's install() writes to Vue.prototype (Vue 2-only; Vue 3 apps have no
-// .prototype), so app.use(Buefy, ...) throws immediately and prevents any page
-// from rendering. Disabled until the Buefy 3 upgrade (Phase 2); <b-*> components
-// render as unstyled/unrecognized elements in the meantime.
-// app.use(Buefy, {
-//   defaultIconComponent: 'font-awesome-icon',
-//   defaultIconPack: 'far'
-// })
+app.use(Buefy, {
+  defaultIconComponent: 'font-awesome-icon',
+  defaultIconPack: 'far'
+})
 app.use(MatchMedia)
 app.use(store)
 app.use(router)
@@ -97,10 +93,7 @@ axios.interceptors.response.use(response => {
   return response
 }, error => {
   if (!error.config.ignoreError && (!lastError || new Date().getTime() - lastError > 9000) && (!error.response || error.response.status !== 404) && mounted) {
-    // SnackbarProgrammatic.open doesn't work with Webpack 5
-    // See https://github.com/buefy/buefy/issues/2299
-    // $buefy is unavailable until the Buefy 3 upgrade (Phase 2, see app.use(Buefy) above).
-    app.config.globalProperties.$buefy?.snackbar.open({
+    app.config.globalProperties.$buefy.snackbar.open({
       duration: 9000,
       message: 'Network or server error while loading data, try again later',
       type: 'is-danger',

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,10 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import Buefy from 'buefy'
-import vueDebounce from 'vue2-debounce'
-import VueClipboard from 'vue-clipboard2'
-import MatchMedia from 'vue-match-media/src'
+// import vueDebounce from 'vue2-debounce'
+// import VueClipboard from 'vue-clipboard2'
+import MatchMedia from './matchmedia'
 import VueKeyCloak from '@dsb-norge/vue-keycloak-js'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCheck, faCheckCircle, faInfoCircle, faExclamationTriangle, faExclamationCircle, faArrowUp, faPlus, faCheckDouble,
@@ -35,17 +35,23 @@ library.add(faMap, fasCheckCircle, fasChevronCircleDown, fasChevronCircleUp, faP
   faFlag, faEnvelope, faLayerGroup, faCity, faBuilding, faHome, faLandmark, faMapMarkerAlt, fasUser, fasMountains,
   fasLocation, faWater, faTree, faRoad)
 library.add(faWikipediaW, faGoogle, faGithub)
-Vue.component('font-awesome-icon', FontAwesomeIcon)
-Vue.component('font-awesome-layers', FontAwesomeLayers)
-Vue.use(vueDebounce)
-Vue.use(VueClipboard)
-Vue.use(Buefy, {
+
+const app = createApp(App)
+app.component('font-awesome-icon', FontAwesomeIcon)
+app.component('font-awesome-layers', FontAwesomeLayers)
+// vue2-debounce and vue-clipboard2 are Vue 2-only (v-debounce/v-clipboard directives
+// are temporarily unavailable, silently no-op in templates) until replaced (Phase 4).
+// app.use(vueDebounce)
+// app.use(VueClipboard)
+app.use(Buefy, {
   defaultIconComponent: 'font-awesome-icon',
   defaultIconPack: 'far'
 })
-Vue.use(MatchMedia)
+app.use(MatchMedia)
+app.use(store)
+app.use(router)
 
-let myVue
+let mounted = false
 
 if (window.performance && performance.navigation.type === 1) {
   // Store last reload timestamp so user reloads can be detected despite SSO redirect
@@ -53,7 +59,7 @@ if (window.performance && performance.navigation.type === 1) {
 }
 
 if (sessionStorage.getItem('wantSso') || localStorage.getItem('wantSso')) {
-  Vue.use(VueKeyCloak, {
+  app.use(VueKeyCloak, {
     config: {
       realm: 'SOTA',
       url: 'https://sso.sota.org.uk/auth',
@@ -68,30 +74,28 @@ if (sessionStorage.getItem('wantSso') || localStorage.getItem('wantSso')) {
         sessionStorage.removeItem('wantSsoLogin')
         keycloak.login()
       } else {
-        startVue()
+        mountApp()
       }
     },
     onInitError: error => {
       console.error('Keycloak error: ' + error)
-      startVue()
+      mountApp()
     },
     autoUpdateToken: false
   })
 } else {
-  startVue()
+  mountApp()
 }
-
-Vue.config.productionTip = false
 
 // Axios error handling
 let lastError = null
 axios.interceptors.response.use(response => {
   return response
 }, error => {
-  if (!error.config.ignoreError && (!lastError || new Date().getTime() - lastError > 9000) && (!error.response || error.response.status !== 404) && myVue) {
+  if (!error.config.ignoreError && (!lastError || new Date().getTime() - lastError > 9000) && (!error.response || error.response.status !== 404) && mounted) {
     // SnackbarProgrammatic.open doesn't work with Webpack 5
     // See https://github.com/buefy/buefy/issues/2299
-    myVue.$buefy.snackbar.open({
+    app.config.globalProperties.$buefy.snackbar.open({
       duration: 9000,
       message: 'Network or server error while loading data, try again later',
       type: 'is-danger',
@@ -105,16 +109,7 @@ axios.interceptors.response.use(response => {
   return Promise.reject(error)
 })
 
-function startVue () {
-  myVue = new Vue({
-    store,
-    router,
-    render: h => h(App),
-    mq: {
-      mobile: '(max-width: 768px)',
-      desktop: '(min-width: 1024px)',
-      widescreen: '(min-width: 1216px)',
-      fullhd: '(min-width: 1408px)'
-    }
-  }).$mount('#app')
+function mountApp () {
+  app.mount('#app')
+  mounted = true
 }

--- a/src/matchmedia.js
+++ b/src/matchmedia.js
@@ -1,0 +1,23 @@
+import { reactive } from 'vue'
+
+// Minimal Vue 3-native replacement for vue-match-media (Vue 2-only, scheduled for
+// full removal in the Vue 3 migration's dependency cleanup phase). Provides the
+// same $mq.{mobile,desktop,widescreen,fullhd} reactive booleans used across the app.
+const queries = {
+  mobile: '(max-width: 768px)',
+  desktop: '(min-width: 1024px)',
+  widescreen: '(min-width: 1216px)',
+  fullhd: '(min-width: 1408px)'
+}
+
+export default {
+  install (app) {
+    const mq = reactive({})
+    for (const key in queries) {
+      const mql = window.matchMedia(queries[key])
+      mq[key] = mql.matches
+      mql.addEventListener('change', e => { mq[key] = e.matches })
+    }
+    app.config.globalProperties.$mq = mq
+  }
+}

--- a/src/mixins/nowticker.js
+++ b/src/mixins/nowticker.js
@@ -6,7 +6,7 @@ export default {
       this.now = moment()
     }, 60000)
   },
-  destroyed () {
+  unmounted () {
     clearInterval(this.nowticker)
   },
   methods: {

--- a/src/mixins/utils.js
+++ b/src/mixins/utils.js
@@ -45,7 +45,39 @@ let modes = {
 }
 
 export default {
-  filters: {
+  computed: {
+    authenticated () {
+      if (this.$keycloak) {
+        return this.$keycloak.authenticated
+      } else {
+        return undefined
+      }
+    },
+    myCallsign () {
+      if (!this.authenticated || !this.$keycloak.tokenParsed.callsign) {
+        return null
+      }
+      return this.homeCallsign(this.$keycloak.tokenParsed.callsign, false)
+    },
+    myUserId () {
+      if (!this.authenticated || !this.$keycloak.tokenParsed.userid) {
+        return null
+      }
+      return parseInt(this.$keycloak.tokenParsed.userid)
+    },
+    isTouchDevice () {
+      let prefixes = ' -webkit- -moz- -o- -ms- '.split(' ')
+      let mq = function (query) {
+        return window.matchMedia(query).matches
+      }
+      if (('ontouchstart' in window) || (window.DocumentTouch && document instanceof window.DocumentTouch)) {
+        return true
+      }
+      let query = ['(', prefixes.join('touch-enabled),('), 'heartz', ')'].join('')
+      return mq(query)
+    }
+  },
+  methods: {
     formatActivationDate (date) {
       return moment.utc(date).format('DD MMM YYYY')
     },
@@ -85,43 +117,6 @@ export default {
       } else {
         return frequency
       }
-    }
-  },
-  computed: {
-    authenticated () {
-      if (this.$keycloak) {
-        return this.$keycloak.authenticated
-      } else {
-        return undefined
-      }
-    },
-    myCallsign () {
-      if (!this.authenticated || !this.$keycloak.tokenParsed.callsign) {
-        return null
-      }
-      return this.homeCallsign(this.$keycloak.tokenParsed.callsign, false)
-    },
-    myUserId () {
-      if (!this.authenticated || !this.$keycloak.tokenParsed.userid) {
-        return null
-      }
-      return parseInt(this.$keycloak.tokenParsed.userid)
-    },
-    isTouchDevice () {
-      let prefixes = ' -webkit- -moz- -o- -ms- '.split(' ')
-      let mq = function (query) {
-        return window.matchMedia(query).matches
-      }
-      if (('ontouchstart' in window) || (window.DocumentTouch && document instanceof window.DocumentTouch)) {
-        return true
-      }
-      let query = ['(', prefixes.join('touch-enabled),('), 'heartz', ')'].join('')
-      return mq(query)
-    }
-  },
-  methods: {
-    formatActivationDate (date) {
-      return moment.utc(date).format('DD MMM YYYY')
     },
     formatTime (date) {
       return moment.utc(date).format('HH:mm') + 'z'

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,5 @@
-import Vue from 'vue'
-import Router from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
+import EventBus from './event-bus'
 import About from './views/About.vue'
 import Settings from './views/Settings.vue'
 import Map from './views/Map.vue'
@@ -19,11 +19,8 @@ import NewPhotos from './views/NewPhotos.vue'
 import SolarHistory from './views/SolarHistory.vue'
 import SearchAnything from './views/SearchAnything.vue'
 
-Vue.use(Router)
-
-let router = new Router({
-  mode: 'history',
-  base: import.meta.env.BASE_URL,
+let router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',
@@ -50,7 +47,7 @@ let router = new Router({
     },
     {
       path: '/map/summits/:summitCode([A-Z0-9]+/[A-Z0-9]{2}-\\d{3})',
-      caseSensitive: true,
+      sensitive: true,
       component: Map,
       meta: { savePath: '/map' }
     },
@@ -77,7 +74,7 @@ let router = new Router({
     },
     {
       path: '/summits/:associationCode([A-Z0-9]+)',
-      caseSensitive: true,
+      sensitive: true,
       component: Association,
       props: true,
       meta: { savePath: null }
@@ -90,7 +87,7 @@ let router = new Router({
     },
     {
       path: '/summits/:regionCode([A-Z0-9]+/[A-Z0-9]{2})',
-      caseSensitive: true,
+      sensitive: true,
       component: Region,
       props: true,
       meta: { savePath: null }
@@ -103,7 +100,7 @@ let router = new Router({
     },
     {
       path: '/summits/:summitCode([A-Z0-9]+/[A-Z0-9]{2}-\\d{3})',
-      caseSensitive: true,
+      sensitive: true,
       component: Summit,
       props: true,
       meta: { savePath: null }
@@ -127,7 +124,7 @@ let router = new Router({
     },
     {
       path: '/activators/:callsign([A-Z0-9/]+)',
-      caseSensitive: true,
+      sensitive: true,
       component: Activator,
       props: true,
       meta: { savePath: null }
@@ -174,7 +171,7 @@ let router = new Router({
       meta: { savePath: null }
     },
     {
-      path: '*',
+      path: '/:pathMatch(.*)*',
       component: NotFound,
       meta: { savePath: null }
     }
@@ -184,9 +181,11 @@ let router = new Router({
       if (savedPosition) {
         let lastMatchedRoute = to.matched[to.matched.length - 1]
         if (lastMatchedRoute.components.default.delayScroll) {
-          this.app.$root.$once('triggerScroll', () => {
+          const onTriggerScroll = () => {
+            EventBus.off('triggerScroll', onTriggerScroll)
             resolve(savedPosition)
-          })
+          }
+          EventBus.on('triggerScroll', onTriggerScroll)
         } else {
           resolve(savedPosition)
         }

--- a/src/store.js
+++ b/src/store.js
@@ -1,11 +1,12 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
-import VueNativeSock from 'vue-native-websocket'
+import { createStore } from 'vuex'
 import EventBus from './event-bus'
 import { decompressKeys } from './keyzipper'
 import axios from 'axios'
 
-Vue.use(Vuex)
+// vue-native-websocket install() is Vue 2-only (relies on Vue.use/Vue.mixin) and
+// isn't called here until it's replaced with a Vue 3-compatible package (Phase 4).
+// Live spot updates over WebSocket are temporarily unavailable until then.
+let socket = null
 
 const MAX_SPOT_AGE = 86400000
 const ALERT_UPDATE_INTERVAL = 300000
@@ -47,7 +48,7 @@ if (mapOptionsSettings) {
   } catch (e) {}
 }
 
-const store = new Vuex.Store({
+const store = createStore({
   state: {
     socket: {
       isConnected: false,
@@ -73,7 +74,7 @@ const store = new Vuex.Store({
   },
   mutations: {
     SOCKET_ONOPEN (state, event) {
-      Vue.prototype.$socket = event.currentTarget
+      socket = event.currentTarget
       state.socket.isConnected = true
       event.currentTarget.sendObj({ rbnFilter: state.rbnFilter })
     },
@@ -92,9 +93,9 @@ const store = new Vuex.Store({
       } else if (message.deleteSpot) {
         deleteSpotById(state, message.deleteSpot.id)
       } else if (message.rbnSpot) {
-        EventBus.$emit('rbnSpot', decompressKeys(message.rbnSpot))
+        EventBus.emit('rbnSpot', decompressKeys(message.rbnSpot))
       } else if (message.rbnSpotHistory) {
-        EventBus.$emit('rbnSpotHistory', decompressKeys(message.rbnSpotHistory), message.viewId)
+        EventBus.emit('rbnSpotHistory', { rbnSpots: decompressKeys(message.rbnSpotHistory), viewId: message.viewId })
       }
     },
     SOCKET_RECONNECT (state, count) {
@@ -106,7 +107,7 @@ const store = new Vuex.Store({
     setRbnFilter (state, newRbnFilter) {
       state.rbnFilter = newRbnFilter
       if (state.socket.isConnected) {
-        Vue.prototype.$socket.sendObj({ rbnFilter: state.rbnFilter })
+        socket.sendObj({ rbnFilter: state.rbnFilter })
       }
     },
     setAlerts (state, newAlerts) {
@@ -187,7 +188,7 @@ function updateSpot (state, spot) {
     state.spots.splice(existingSpotIndex, 1, spot)
   } else {
     state.spots.push(spot)
-    EventBus.$emit('sotaSpot', spot)
+    EventBus.emit('sotaSpot', spot)
   }
   removeExpiredSpots(state)
 }
@@ -226,11 +227,7 @@ function loadAlerts (noCache) {
 loadAlerts(false)
 setInterval(loadAlerts, ALERT_UPDATE_INTERVAL)
 
-Vue.use(VueNativeSock, import.meta.env.VITE_WSS_URL + '/ws', {
-  format: 'json',
-  store,
-  reconnection: true,
-  reconnectionDelay: 1000
-})
+// WebSocket connection setup (vue-native-websocket) is temporarily disabled,
+// see the `socket` variable comment above.
 
 export default store

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -2,7 +2,7 @@
   <PageLayout>
     <template v-slot:title>About</template>
 
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container content">
           <p>SOTA Atlas (SOTLAS) is created and maintained by Manuel Kasper, HB9DQM (<a href="mailto:mk@neon1.net">mk@neon1.net</a>).</p>

--- a/src/views/Activation.vue
+++ b/src/views/Activation.vue
@@ -3,7 +3,7 @@
     <template v-slot:title>Activation</template>
     <template v-if="activationDetails" v-slot:subtitle><router-link :to="makeActivatorLinkUserId(activationDetails.UserID)">{{ activationDetails.OwnCallsign }}</router-link> on <router-link :to="makeSummitLink(summitCode)">{{ activationDetails.Summit }}</router-link>, <span class="activation-date">{{ niceActivationDate }}</span></template>
 
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container">
           <QSOList v-if="activationDetails" :data="activationDetails.ActivatorLogs" />

--- a/src/views/Activator.vue
+++ b/src/views/Activator.vue
@@ -19,7 +19,7 @@
       </div>
     </template>
 
-    <template>
+    <template v-slot:default>
       <section v-if="recentSpots.length > 0 || $store.state.spots.length === 0" class="section">
         <div class="container">
 

--- a/src/views/Activator.vue
+++ b/src/views/Activator.vue
@@ -319,7 +319,7 @@ export default {
         }
       }
     },
-    receiveRbnSpotHistory (rbnSpots, viewId) {
+    receiveRbnSpotHistory ({ rbnSpots, viewId }) {
       if (viewId === this.viewId) {
         this.rbnSpots = rbnSpots
       }
@@ -381,7 +381,7 @@ export default {
 
       Promise.all(loads)
         .then(() => {
-          this.$root.$emit('triggerScroll')
+          EventBus.emit('triggerScroll')
         })
 
       this.$store.commit('setRbnFilter', { homeCallsign: this.homeCallsign(this.callsign), maxAge: 86400000, viewId: this.viewId })
@@ -389,13 +389,13 @@ export default {
   },
   mounted () {
     this.updateCallsign()
-    EventBus.$on('rbnSpot', this.receiveRbnSpot)
-    EventBus.$on('rbnSpotHistory', this.receiveRbnSpotHistory)
+    EventBus.on('rbnSpot', this.receiveRbnSpot)
+    EventBus.on('rbnSpotHistory', this.receiveRbnSpotHistory)
   },
-  destroyed () {
+  unmounted () {
     this.$store.commit('setRbnFilter', {})
-    EventBus.$off('rbnSpot', this.receiveRbnSpot)
-    EventBus.$off('rbnSpotHistory', this.receiveRbnSpotHistory)
+    EventBus.off('rbnSpot', this.receiveRbnSpot)
+    EventBus.off('rbnSpotHistory', this.receiveRbnSpotHistory)
   },
   data () {
     return {

--- a/src/views/Activators.vue
+++ b/src/views/Activators.vue
@@ -9,8 +9,8 @@
             <FilterInput v-model="filter" ref="filter" v-debounce:500ms="onFilterChanged" />
           </b-field>
 
-          <b-table class="auto-width" :narrowed="true" :striped="true" :data="activators" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" :current-page.sync="curPage" backend-sorting :default-sort="[sortField, sortDirection]" @sort="onSort" :mobile-cards="false">
-            <template slot-scope="props">
+          <b-table class="auto-width" :narrowed="true" :striped="true" :data="activators" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" v-model:current-page="curPage" backend-sorting :default-sort="[sortField, sortDirection]" @sort="onSort" :mobile-cards="false">
+            <template v-slot="props">
               <b-table-column field="callsign" label="Callsign" class="nowrap" sortable>
                 <CountryFlag :country="country(props.row.callsign)" class="flag" />
                 <router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link>

--- a/src/views/Activators.vue
+++ b/src/views/Activators.vue
@@ -2,7 +2,7 @@
   <PageLayout>
     <template v-slot:title>Activators</template>
 
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container">
           <b-field>
@@ -10,27 +10,25 @@
           </b-field>
 
           <b-table class="auto-width" :narrowed="true" :striped="true" :data="activators" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" v-model:current-page="curPage" backend-sorting :default-sort="[sortField, sortDirection]" @sort="onSort" :mobile-cards="false">
-            <template v-slot="props">
-              <b-table-column field="callsign" label="Callsign" class="nowrap" sortable>
-                <CountryFlag :country="country(props.row.callsign)" class="flag" />
-                <router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link>
-              </b-table-column>
-              <b-table-column field="summits" :label="$mq.mobile ? 'Act.' : 'Activations'" numeric sortable>
-                {{ props.row.summits }}
-              </b-table-column>
-              <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" numeric sortable>
-                {{ props.row.points }}
-              </b-table-column>
-              <b-table-column field="bonusPoints" :label="$mq.mobile ? 'Bonus' : 'Bonus points'" numeric sortable>
-                {{ props.row.bonusPoints }}
-              </b-table-column>
-              <b-table-column field="score" label="Score" numeric sortable>
-                {{ props.row.score }}
-              </b-table-column>
-              <b-table-column v-if="!$mq.mobile" field="avgPoints" label="Avg. points" numeric sortable>
-                {{ props.row.avgPoints }}
-              </b-table-column>
-            </template>
+            <b-table-column field="callsign" label="Callsign" class="nowrap" sortable v-slot="props">
+              <CountryFlag :country="country(props.row.callsign)" class="flag" />
+              <router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link>
+            </b-table-column>
+            <b-table-column field="summits" :label="$mq.mobile ? 'Act.' : 'Activations'" numeric sortable v-slot="props">
+              {{ props.row.summits }}
+            </b-table-column>
+            <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" numeric sortable v-slot="props">
+              {{ props.row.points }}
+            </b-table-column>
+            <b-table-column field="bonusPoints" :label="$mq.mobile ? 'Bonus' : 'Bonus points'" numeric sortable v-slot="props">
+              {{ props.row.bonusPoints }}
+            </b-table-column>
+            <b-table-column field="score" label="Score" numeric sortable v-slot="props">
+              {{ props.row.score }}
+            </b-table-column>
+            <b-table-column v-if="!$mq.mobile" field="avgPoints" label="Avg. points" numeric sortable v-slot="props">
+              {{ props.row.avgPoints }}
+            </b-table-column>
             <template v-slot:bottom-left>
               <b-select v-model="perPage">
                 <option v-for="option in perPageOptions" :key="option" :value="option">{{ option }} per page</option>

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -24,17 +24,21 @@
           <b-field grouped group-multiline>
             <FilterInput class="control" v-model="alertFilter" placeholder="Summit or callsign" :is-regex="true" />
             <b-dropdown class="control" v-model="selectedModes" multiple aria-role="list">
-              <b-button icon-right="angle-down" slot="trigger">
-                  Modes {{ selectedModes.length > 0 ? ('(' + selectedModes.length + ')') : '' }}
-              </b-button>
+              <template v-slot:trigger>
+                <b-button icon-right="angle-down">
+                    Modes {{ selectedModes.length > 0 ? ('(' + selectedModes.length + ')') : '' }}
+                </b-button>
+              </template>
               <b-dropdown-item v-for="(mode, key) in modes" :key="key" :value="key" aria-role="listitem">
                 {{ mode }}
               </b-dropdown-item>
             </b-dropdown>
             <b-dropdown class="control" v-model="selectedContinents" multiple aria-role="list">
-              <b-button icon-right="angle-down" slot="trigger">
-                  Continents {{ selectedContinents.length > 0 ? ('(' + selectedContinents.length + ')') : '' }}
-              </b-button>
+              <template v-slot:trigger>
+                <b-button icon-right="angle-down">
+                    Continents {{ selectedContinents.length > 0 ? ('(' + selectedContinents.length + ')') : '' }}
+                </b-button>
+              </template>
               <b-dropdown-item v-for="(continent, code) in continents" :key="code" :value="code" aria-role="listitem">
                 {{ continent }}
               </b-dropdown-item>

--- a/src/views/Alerts.vue
+++ b/src/views/Alerts.vue
@@ -18,7 +18,7 @@
       </div>
     </template>
 
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container">
           <b-field grouped group-multiline>

--- a/src/views/Association.vue
+++ b/src/views/Association.vue
@@ -16,20 +16,18 @@
         <div class="columns">
           <div class="column">
             <b-table default-sort="code" :narrowed="true" :striped="true" :data="filteredRegions" :mobile-cards="false">
-              <template v-slot="props">
-                <b-table-column field="code" label="Identifier" class="nowrap" sortable>
-                  <router-link :to="regionLink(props.row)">{{ props.row.code }}</router-link>
-                </b-table-column>
-                <b-table-column field="name" label="Name" sortable>
-                  <router-link :to="regionLink(props.row)">{{ props.row.name }}</router-link>
-                </b-table-column>
-                <b-table-column field="summitCount" label="Summits" sortable numeric>
-                  {{ props.row.summitCount }}
-                </b-table-column>
-                <b-table-column v-if="myActivationsPerRegion" :label="$mq.mobile ? 'Act. by me' : 'Activated by me'" numeric>
-                  {{ myActivationsPerRegion[associationCode + '/' + props.row.code] }}
-                </b-table-column>
-              </template>
+              <b-table-column field="code" label="Identifier" class="nowrap" sortable v-slot="props">
+                <router-link :to="regionLink(props.row)">{{ props.row.code }}</router-link>
+              </b-table-column>
+              <b-table-column field="name" label="Name" sortable v-slot="props">
+                <router-link :to="regionLink(props.row)">{{ props.row.name }}</router-link>
+              </b-table-column>
+              <b-table-column field="summitCount" label="Summits" sortable numeric v-slot="props">
+                {{ props.row.summitCount }}
+              </b-table-column>
+              <b-table-column v-if="myActivationsPerRegion" :label="$mq.mobile ? 'Act. by me' : 'Activated by me'" numeric v-slot="props">
+                {{ myActivationsPerRegion[associationCode + '/' + props.row.code] }}
+              </b-table-column>
             </b-table>
           </div>
           <div class="column">

--- a/src/views/Association.vue
+++ b/src/views/Association.vue
@@ -16,7 +16,7 @@
         <div class="columns">
           <div class="column">
             <b-table default-sort="code" :narrowed="true" :striped="true" :data="filteredRegions" :mobile-cards="false">
-              <template slot-scope="props">
+              <template v-slot="props">
                 <b-table-column field="code" label="Identifier" class="nowrap" sortable>
                   <router-link :to="regionLink(props.row)">{{ props.row.code }}</router-link>
                 </b-table-column>
@@ -45,6 +45,7 @@
 import axios from 'axios'
 import utils from '../mixins/utils.js'
 import sotadb from '../mixins/sotadb.js'
+import EventBus from '../event-bus'
 
 import SummitDatabasePageLayout from '../components/SummitDatabasePageLayout.vue'
 import FilterInput from '../components/FilterInput.vue'
@@ -84,7 +85,7 @@ export default {
           this.association = response.data
           document.title = this.association.name + ' (' + this.associationCode + ') - SOTLAS'
           this.loadingComponent.close()
-          this.$root.$emit('triggerScroll')
+          EventBus.emit('triggerScroll')
         })
         .catch(error => {
           this.loadingComponent.close()

--- a/src/views/AssociationList.vue
+++ b/src/views/AssociationList.vue
@@ -12,20 +12,18 @@
           <FilterInput v-model="filter" ref="filter" />
         </b-field>
         <b-table class="auto-width" default-sort="code" :narrowed="true" :striped="true" :data="filteredAssociations" :mobile-cards="false">
-          <template v-slot="props">
-            <b-table-column field="code" label="Identifier" class="nowrap" sortable>
-              <router-link :to="associationLink(props.row)">{{ props.row.code }}</router-link>
-            </b-table-column>
-            <b-table-column field="name" label="Name" sortable>
-              <router-link :to="associationLink(props.row)">{{ props.row.name }}</router-link>
-            </b-table-column>
-            <b-table-column field="summitCount" label="Summits" sortable>
-              {{ props.row.summitCount }}
-            </b-table-column>
-            <b-table-column v-if="myActivationsPerAssociation" :label="$mq.mobile ? 'Act. by me' : 'Activated by me'" numeric>
-              {{ myActivationsPerAssociation[props.row.code] }}
-            </b-table-column>
-          </template>
+          <b-table-column field="code" label="Identifier" class="nowrap" sortable v-slot="props">
+            <router-link :to="associationLink(props.row)">{{ props.row.code }}</router-link>
+          </b-table-column>
+          <b-table-column field="name" label="Name" sortable v-slot="props">
+            <router-link :to="associationLink(props.row)">{{ props.row.name }}</router-link>
+          </b-table-column>
+          <b-table-column field="summitCount" label="Summits" sortable v-slot="props">
+            {{ props.row.summitCount }}
+          </b-table-column>
+          <b-table-column v-if="myActivationsPerAssociation" :label="$mq.mobile ? 'Act. by me' : 'Activated by me'" numeric v-slot="props">
+            {{ myActivationsPerAssociation[props.row.code] }}
+          </b-table-column>
         </b-table>
       </div>
     </section>

--- a/src/views/AssociationList.vue
+++ b/src/views/AssociationList.vue
@@ -12,7 +12,7 @@
           <FilterInput v-model="filter" ref="filter" />
         </b-field>
         <b-table class="auto-width" default-sort="code" :narrowed="true" :striped="true" :data="filteredAssociations" :mobile-cards="false">
-          <template slot-scope="props">
+          <template v-slot="props">
             <b-table-column field="code" label="Identifier" class="nowrap" sortable>
               <router-link :to="associationLink(props.row)">{{ props.row.code }}</router-link>
             </b-table-column>
@@ -35,6 +35,7 @@
 <script>
 import axios from 'axios'
 import sotadb from '../mixins/sotadb.js'
+import EventBus from '../event-bus'
 
 import SummitDatabasePageLayout from '../components/SummitDatabasePageLayout.vue'
 import FilterInput from '../components/FilterInput.vue'
@@ -58,7 +59,7 @@ export default {
       .then(response => {
         this.associations = response.data
         this.loadingComponent.close()
-        this.$root.$emit('triggerScroll')
+        EventBus.emit('triggerScroll')
       })
 
     if (this.authenticated) {

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="map-layout" ref="mapLayout">
-    <MglMap v-if="showMap && mapStyle" :apiKey="mapTilerApiKey" :mapStyle="mapStyle" :bounds.sync="bounds" :fitBoundsOptions="fitBoundsOptions" :center="center" :zoom="zoom" :dragRotate="false" :attributionControl="false" class="map" @load="onMapLoaded" @click="onMapClicked" @contextmenu="onMapRightClicked">
+    <MglMap v-if="showMap && mapStyle" :apiKey="mapTilerApiKey" :mapStyle="mapStyle" v-model:bounds="bounds" :fitBoundsOptions="fitBoundsOptions" :center="center" :zoom="zoom" :dragRotate="false" :attributionControl="false" class="map" @load="onMapLoaded" @click="onMapClicked" @contextmenu="onMapRightClicked">
       <MglGeolocateControl :positionOptions="{ enableHighAccuracy: true }" :fitBoundsOptions="{ maxZoom: 12.5 }" :trackUserLocation="true" position="top-right" />
       <MglNavigationControl position="top-right" :showCompass="false" />
       <MglScaleControl position="bottom-left" :unit="mapUnits" />

--- a/src/views/NewPhotos.vue
+++ b/src/views/NewPhotos.vue
@@ -20,7 +20,7 @@
         </b-dropdown>
       </b-field>
     </template>
-    <template>
+    <template v-slot:default>
       <section v-if="summits !== null && summits.length > 0" class="section">
         <div class="container">
           <SummitPhotos v-for="summit in summits" :key="summit.code" :summit="summit" :minDate="minDate" :showSummitName="true" />

--- a/src/views/NewPhotos.vue
+++ b/src/views/NewPhotos.vue
@@ -4,14 +4,16 @@
     <template v-slot:title-right>
       <b-field>
         <b-dropdown class="control" v-model="selectedAssociations" multiple aria-role="list" position="is-bottom-left" :scrollable="$mq.desktop" @change="loadNewPhotos">
-          <b-button icon-left="globe" icon-right="angle-down" slot="trigger">
-            <template v-if="$mq.mobile">
-              {{ selectedAssociations.length > 0 ? (selectedAssociations.length) : '' }}
-            </template>
-            <template v-else>
-              Associations {{ selectedAssociations.length > 0 ? ('(' + selectedAssociations.length + ')') : '' }}
-            </template>
-          </b-button>
+          <template v-slot:trigger>
+            <b-button icon-left="globe" icon-right="angle-down">
+              <template v-if="$mq.mobile">
+                {{ selectedAssociations.length > 0 ? (selectedAssociations.length) : '' }}
+              </template>
+              <template v-else>
+                Associations {{ selectedAssociations.length > 0 ? ('(' + selectedAssociations.length + ')') : '' }}
+              </template>
+            </b-button>
+          </template>
           <b-dropdown-item v-for="association in associations" :key="association.code" :value="association.code" aria-role="listitem">
             {{ association.code }} – {{ association.name }}
           </b-dropdown-item>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -2,7 +2,7 @@
   <PageLayout>
     <template v-slot:title>Not Found</template>
 
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container">
           <b-message title="Not Found" type="is-danger">

--- a/src/views/RBNSpots.vue
+++ b/src/views/RBNSpots.vue
@@ -5,17 +5,21 @@
         <b-field grouped group-multiline>
           <FilterInput class="filter-input" v-model="spotFilter" placeholder="Callsign" :is-regex="true" />
           <b-dropdown class="control" v-model="selectedBands" multiple aria-role="list">
-            <b-button icon-right="angle-down" slot="trigger">
-                Bands {{ selectedBands.length > 0 ? ('(' + selectedBands.length + ')') : '' }}
-            </b-button>
+            <template v-slot:trigger>
+              <b-button icon-right="angle-down">
+                  Bands {{ selectedBands.length > 0 ? ('(' + selectedBands.length + ')') : '' }}
+              </b-button>
+            </template>
             <b-dropdown-item v-for="band in bands" :key="band" :value="band" aria-role="listitem">
               {{ band }}
             </b-dropdown-item>
           </b-dropdown>
           <b-dropdown class="control" v-model="selectedContinentsCS" multiple aria-role="list">
-            <b-button icon-right="angle-down" slot="trigger">
-                Continents {{ selectedContinentsCS.length > 0 ? ('(' + selectedContinentsCS.length + ')') : '' }}
-            </b-button>
+            <template v-slot:trigger>
+              <b-button icon-right="angle-down">
+                  Continents {{ selectedContinentsCS.length > 0 ? ('(' + selectedContinentsCS.length + ')') : '' }}
+              </b-button>
+            </template>
             <b-dropdown-item :custom="true" :disabled="true"><strong>Callsign</strong></b-dropdown-item>
             <b-dropdown-item v-for="(continent, code) in continents" :key="'callsign_' + code" :value="'callsign_' + code" aria-role="listitem">
               {{ continent }}
@@ -80,13 +84,13 @@ export default {
   mounted () {
     this.loadPrefs()
 
-    EventBus.$on('rbnSpot', this.receiveRbnSpot)
-    EventBus.$on('rbnSpotHistory', this.receiveRbnSpotHistory)
+    EventBus.on('rbnSpot', this.receiveRbnSpot)
+    EventBus.on('rbnSpotHistory', this.receiveRbnSpotHistory)
     this.$store.commit('setRbnFilter', { isActivator: true, maxAge: MAX_SPOT_AGE, viewId: this.viewId })
   },
-  destroyed () {
-    EventBus.$off('rbnSpot', this.receiveRbnSpot)
-    EventBus.$off('rbnSpotHistory', this.receiveRbnSpotHistory)
+  unmounted () {
+    EventBus.off('rbnSpot', this.receiveRbnSpot)
+    EventBus.off('rbnSpotHistory', this.receiveRbnSpotHistory)
     this.$store.commit('setRbnFilter', {})
   },
   methods: {
@@ -101,11 +105,11 @@ export default {
         this.removeExpiredSpots()
       }
     },
-    receiveRbnSpotHistory (rbnSpots, viewId) {
+    receiveRbnSpotHistory ({ rbnSpots, viewId }) {
       if (viewId === this.viewId) {
         this.loading = false
         this.rbnSpots = rbnSpots
-        this.$root.$emit('triggerScroll')
+        EventBus.emit('triggerScroll')
       }
     },
     removeExpiredSpots () {

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -34,6 +34,7 @@ import moment from 'moment'
 import utils from '../mixins/utils.js'
 import prefs from '../mixins/prefs.js'
 import sotadb from '../mixins/sotadb.js'
+import EventBus from '../event-bus'
 
 import SummitDatabasePageLayout from '../components/SummitDatabasePageLayout.vue'
 import FilterInput from '../components/FilterInput.vue'
@@ -157,7 +158,7 @@ export default {
       Promise.all(loads)
         .then(() => {
           this.loadingComponent.close()
-          this.$root.$emit('triggerScroll')
+          EventBus.emit('triggerScroll')
         })
     }
   },

--- a/src/views/SearchAnything.vue
+++ b/src/views/SearchAnything.vue
@@ -22,7 +22,7 @@
           <h4 class="title is-4"><b-icon icon="user" />Activators</h4>
 
           <b-table class="auto-width" default-sort="callsign" :narrowed="true" :striped="true" :data="activators" :mobile-cards="false">
-            <template slot-scope="props">
+            <template v-slot="props">
               <b-table-column field="callsign" label="Callsign" sortable>
                 <router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link>
               </b-table-column>
@@ -55,7 +55,7 @@
           <h4 class="title is-4"><b-icon icon="map-marker-alt" pack="fas" />Places</h4>
 
           <b-table class="auto-width" :narrowed="true" :striped="true" :data="places" :mobile-cards="false">
-            <template slot-scope="props">
+            <template v-slot="props">
               <b-table-column field="label" label="Name">
                 <b-icon :icon="iconForFeatureClass(props.row.featureClass)" size="is-small" class="has-text-grey search-result-icon" pack="fas" />
                 <a @click="goToPlace(props.row)">{{ props.row.label }}</a>

--- a/src/views/SearchAnything.vue
+++ b/src/views/SearchAnything.vue
@@ -1,7 +1,7 @@
 <template>
   <PageLayout>
     <template v-slot:title>Search results</template>
-    <template>
+    <template v-slot:default>
       <section v-if="summits !== null && summits.length > 0" class="section">
         <div class="container">
           <h4 class="title is-4"><b-icon icon="mountains" />Summits</h4>
@@ -22,26 +22,24 @@
           <h4 class="title is-4"><b-icon icon="user" />Activators</h4>
 
           <b-table class="auto-width" default-sort="callsign" :narrowed="true" :striped="true" :data="activators" :mobile-cards="false">
-            <template v-slot="props">
-              <b-table-column field="callsign" label="Callsign" sortable>
-                <router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link>
-              </b-table-column>
-              <b-table-column field="summits" label="Summits" numeric sortable>
-                {{ props.row.summits }}
-              </b-table-column>
-              <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" numeric sortable>
-                {{ props.row.points }}
-              </b-table-column>
-              <b-table-column field="bonusPoints" :label="$mq.mobile ? 'Bonus' : 'Bonus points'" numeric sortable>
-                {{ props.row.bonusPoints }}
-              </b-table-column>
-              <b-table-column field="score" label="Score" numeric sortable>
-                {{ props.row.score }}
-              </b-table-column>
-              <b-table-column v-if="!$mq.mobile" field="avgPoints" label="Avg. points" numeric sortable>
-                {{ props.row.avgPoints }}
-              </b-table-column>
-            </template>
+            <b-table-column field="callsign" label="Callsign" sortable v-slot="props">
+              <router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link>
+            </b-table-column>
+            <b-table-column field="summits" label="Summits" numeric sortable v-slot="props">
+              {{ props.row.summits }}
+            </b-table-column>
+            <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" numeric sortable v-slot="props">
+              {{ props.row.points }}
+            </b-table-column>
+            <b-table-column field="bonusPoints" :label="$mq.mobile ? 'Bonus' : 'Bonus points'" numeric sortable v-slot="props">
+              {{ props.row.bonusPoints }}
+            </b-table-column>
+            <b-table-column field="score" label="Score" numeric sortable v-slot="props">
+              {{ props.row.score }}
+            </b-table-column>
+            <b-table-column v-if="!$mq.mobile" field="avgPoints" label="Avg. points" numeric sortable v-slot="props">
+              {{ props.row.avgPoints }}
+            </b-table-column>
           </b-table>
 
           <b-message v-if="activators !== null && activators.length === this.limit" type="is-warning" has-icon>
@@ -55,15 +53,13 @@
           <h4 class="title is-4"><b-icon icon="map-marker-alt" pack="fas" />Places</h4>
 
           <b-table class="auto-width" :narrowed="true" :striped="true" :data="places" :mobile-cards="false">
-            <template v-slot="props">
-              <b-table-column field="label" label="Name">
-                <b-icon :icon="iconForFeatureClass(props.row.featureClass)" size="is-small" class="has-text-grey search-result-icon" pack="fas" />
-                <a @click="goToPlace(props.row)">{{ props.row.label }}</a>
-              </b-table-column>
-              <b-table-column field="detail" label="Detail">
-                {{ props.row.detail }}
-              </b-table-column>
-            </template>
+            <b-table-column field="label" label="Name" v-slot="props">
+              <b-icon :icon="iconForFeatureClass(props.row.featureClass)" size="is-small" class="has-text-grey search-result-icon" pack="fas" />
+              <a @click="goToPlace(props.row)">{{ props.row.label }}</a>
+            </b-table-column>
+            <b-table-column field="detail" label="Detail" v-slot="props">
+              {{ props.row.detail }}
+            </b-table-column>
           </b-table>
         </div>
       </section>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -2,7 +2,7 @@
   <PageLayout>
     <template v-slot:title>Settings</template>
 
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container content">
           <b-field label="Units">

--- a/src/views/SolarHistory.vue
+++ b/src/views/SolarHistory.vue
@@ -1,7 +1,7 @@
 <template>
   <PageLayout>
     <template v-slot:title>Solar Data</template>
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container content">
           <LineChart class="solar-chart" v-if="solarHistory !== null" :data="solarHistory" labelField="dateFormatted" valueField="sfi" valueFieldB="r" name="SFI" nameB="SN" :xIsSeries="true" :regionFill="false" spline="1" height="400" />

--- a/src/views/SotaSpots.vue
+++ b/src/views/SotaSpots.vue
@@ -5,25 +5,31 @@
         <b-field grouped group-multiline>
           <FilterInput class="control" v-model="spotFilter" placeholder="Summit or callsign" :is-regex="true" />
           <b-dropdown class="control" v-model="selectedBands" multiple aria-role="list">
-            <b-button icon-right="angle-down" slot="trigger">
-                Bands {{ selectedBands.length > 0 ? ('(' + selectedBands.length + ')') : '' }}
-            </b-button>
+            <template v-slot:trigger>
+              <b-button icon-right="angle-down">
+                  Bands {{ selectedBands.length > 0 ? ('(' + selectedBands.length + ')') : '' }}
+              </b-button>
+            </template>
             <b-dropdown-item v-for="band in bands" :key="band" :value="band" aria-role="listitem">
               {{ band }}
             </b-dropdown-item>
           </b-dropdown>
           <b-dropdown class="control" v-model="selectedModes" multiple aria-role="list">
-            <b-button icon-right="angle-down" slot="trigger">
-                Modes {{ selectedModes.length > 0 ? ('(' + selectedModes.length + ')') : '' }}
-            </b-button>
+            <template v-slot:trigger>
+              <b-button icon-right="angle-down">
+                  Modes {{ selectedModes.length > 0 ? ('(' + selectedModes.length + ')') : '' }}
+              </b-button>
+            </template>
             <b-dropdown-item v-for="(mode, key) in modes" :key="key" :value="key" aria-role="listitem">
               {{ mode }}
             </b-dropdown-item>
           </b-dropdown>
           <b-dropdown class="control" v-model="selectedContinents" multiple aria-role="list">
-            <b-button icon-right="angle-down" slot="trigger">
-                Continents {{ selectedContinents.length > 0 ? ('(' + selectedContinents.length + ')') : '' }}
-            </b-button>
+            <template v-slot:trigger>
+              <b-button icon-right="angle-down">
+                  Continents {{ selectedContinents.length > 0 ? ('(' + selectedContinents.length + ')') : '' }}
+              </b-button>
+            </template>
             <b-dropdown-item v-for="(continent, code) in continents" :key="code" :value="code" aria-role="listitem">
               {{ continent }}
             </b-dropdown-item>
@@ -64,10 +70,10 @@ export default {
     props: ['spotFilter', 'selectedBands', 'selectedModes', 'selectedContinents', 'unmuted']
   },
   mounted () {
-    EventBus.$on('sotaSpot', this.receiveSotaSpot)
+    EventBus.on('sotaSpot', this.receiveSotaSpot)
   },
-  destroyed () {
-    EventBus.$off('sotaSpot', this.receiveSotaSpot)
+  unmounted () {
+    EventBus.off('sotaSpot', this.receiveSotaSpot)
   },
   methods: {
     clearFilters () {

--- a/src/views/Spots.vue
+++ b/src/views/Spots.vue
@@ -8,7 +8,7 @@
       </div>
     </template>
 
-    <template>
+    <template v-slot:default>
       <section class="section">
         <div class="container">
           <div class="tabs">

--- a/src/views/Summit.vue
+++ b/src/views/Summit.vue
@@ -34,7 +34,7 @@
       </p>
 
       <b-message v-if="!isValid" type="is-warning" has-icon>
-        This summit is currently not valid (valid from {{ summit.validFrom | formatActivationDate }} to {{ summit.validTo | formatActivationDate }}).
+        This summit is currently not valid (valid from {{ formatActivationDate(summit.validFrom) }} to {{ formatActivationDate(summit.validTo) }}).
       </b-message>
 
       <b-message v-else-if="activations !== null && activations.length == 0" type="is-info" has-icon>
@@ -66,7 +66,7 @@
               <span v-if="firstActivations.activators.length > 1"> (with
                 <span v-for="(activator, index) in firstActivations.activators.slice(1)" :key="activator.userId"><FirstActivator :callsign="activator.callsign" :userId="activator.userId" />{{ index !== firstActivations.activators.length - 2 ? ' & ' : '' }}</span>)
               </span>
-            <span class="has-text-grey"> on {{ firstActivations.date | formatActivationDate }}</span></div>
+            <span class="has-text-grey"> on {{ formatActivationDate(firstActivations.date) }}</span></div>
 
             <SummitAttributes :summit-code="summit.code" />
 
@@ -353,10 +353,10 @@ export default {
   },
   mounted () {
     this.updateSummit()
-    EventBus.$on('navbarMenuOpened', this.navbarMenuOpened)
+    EventBus.on('navbarMenuOpened', this.navbarMenuOpened)
   },
-  destroyed () {
-    EventBus.$off('navbarMenuOpened', this.navbarMenuOpened)
+  unmounted () {
+    EventBus.off('navbarMenuOpened', this.navbarMenuOpened)
   },
   methods: {
     updateSummit (force = false) {
@@ -469,20 +469,20 @@ export default {
       this.isAddSpotActive = true
     },
     routeDetailsOpen (route) {
-      this.$set(route, 'highlight', true)
+      route.highlight = true
       this.routes.forEach(curRoute => {
         if (curRoute.highlight !== true) {
-          this.$set(curRoute, 'highlight', false)
+          curRoute.highlight = false
         }
       })
     },
     routeDetailsClose (route) {
-      this.$set(route, 'highlight', false)
+      route.highlight = false
 
       // If all route highlights are false, set them all to null
       if (this.routes.every(curRoute => curRoute.highlight === false)) {
         this.routes.forEach(curRoute => {
-          this.$set(curRoute, 'highlight', null)
+          curRoute.highlight = null
         })
       }
     },

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig, loadEnv } from 'vite';
-import vue from '@vitejs/plugin-vue2';
+import vue from '@vitejs/plugin-vue';
 import fs from 'fs';
 import path from 'path';
 import eslint from 'vite-plugin-eslint'
@@ -76,11 +76,6 @@ export default defineConfig(async ({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, 'src'),
-        // vue-filepond imports the extension-less 'vue/dist/vue.esm', which
-        // @vitejs/plugin-vue2's automatic 'vue' alias (prefix-matched) rewrites
-        // into a nonexistent path. Pin the exact id first so it resolves to
-        // the real file instead.
-        'vue/dist/vue.esm': 'vue/dist/vue.esm.js',
         ...(useProIcons ? {} : {
           '@fortawesome/pro-regular-svg-icons': path.resolve(__dirname, 'src/fa-pro-fallback/regular.js'),
           '@fortawesome/pro-solid-svg-icons': path.resolve(__dirname, 'src/fa-pro-fallback/solid.js')


### PR DESCRIPTION
As discussed in #44, this is the first PR of the Vue 3 migration, against the `vue3` branch: Phases 1 (core swap) and 2 (Buefy 0.8 → 3.0, Bulma 0.7 → 1.0) of the plan posted there. One concern per commit; each commit message documents what changed, why, and how it was verified — including the breaking changes discovered along the way.

**State after this PR** (matches the progress reports in #44):

- Builds and boots on Vue 3.5 (vue-router 4, vuex 4, mitt event bus, Options API kept throughout)
- Styled again with Buefy 3 + Bulma 1.0 (current light-only look preserved via `bulma/versions/bulma-no-dark-mode`)
- Data pages (Activators, Alerts, Associations, Region, Summit) render with live data — spot-checked against production rather than a full page-by-page pass
- Known-broken at this stage, by design: map summit markers/controls (vue-mapbox is Vue 2-only — Phase 3, in progress on my fork), live spots over WebSocket, and photo galleries (Phase 4 libraries)

**Review notes:**

- The commits are the same as on my fork's `feat/vue3-migration` (the compare link already posted in #44), rebased onto `vue3` with the commit messages translated to English
- `package.json` `overrides` pins the remaining Vue 2-only libraries to vue 3 to avoid ERESOLVE at install time; each override gets removed as its library is migrated in a later phase
- Two decisions you may want to weigh in on (both mentioned in #44): the `no-dark-mode` Bulma import (keeps the current look; dark mode could be revisited as a feature later), and the `$link: $blue` Sass override that doesn't carry over to Bulma 1.0's module system (links currently use the 1.0 default blue)

`npm run lint` (zero warnings) and `npm run build` pass on this branch standalone.
