### PR TITLE
Vue 3 migration - Phase 4 (replace remaining Vue 2-only libraries)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "vue-infinite-loading": "^2.4.5",
         "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
         "vue-router": "^4.6.4",
-        "vue2-debounce": "^1.0.1",
         "vuedraggable": "^4.1.0",
         "vuex": "^4.1.0"
       },
@@ -5521,15 +5520,6 @@
       },
       "peerDependencies": {
         "vue": "^3.5.0"
-      }
-    },
-    "node_modules/vue2-debounce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vue2-debounce/-/vue2-debounce-1.0.1.tgz",
-      "integrity": "sha512-tZX6QltRUuGn9WUUVJDTWUmAqGugIUKcQN4praNAW4ZQPtBIyyZfvCLq7hKOOSdFhVRloXeFnCZvETibEgKNOw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": ">= 2.0.0 < 3.0.0"
       }
     },
     "node_modules/vuedraggable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "photoswipe": "^4.1.3",
         "proj4": "^2.7.2",
         "vue": "^3.5.39",
-        "vue-clipboard2": "^0.3.1",
         "vue-filepond": "^8.0.0",
         "vue-infinite-loading": "^2.4.5",
         "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
@@ -2279,17 +2278,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/clipboard": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "license": "MIT",
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2475,12 +2463,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -3340,15 +3322,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "license": "MIT",
-      "dependencies": {
-        "delegate": "^3.1.2"
       }
     },
     "node_modules/gopd": {
@@ -4828,12 +4801,6 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -5110,12 +5077,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "license": "MIT"
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -5496,15 +5457,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vue-clipboard2": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/vue-clipboard2/-/vue-clipboard2-0.3.3.tgz",
-      "integrity": "sha512-aNWXIL2DKgJyY/1OOeITwAQz1fHaCIGvUFHf9h8UcoQBG5a74MkdhS/xqoYe7DNZdQmZRL+TAdIbtUs9OyVjbw==",
-      "license": "MIT",
-      "dependencies": {
-        "clipboard": "^2.0.0"
       }
     },
     "node_modules/vue-eslint-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
         "node-vincenty": "0.0.6",
         "photoswipe": "^4.1.3",
         "proj4": "^2.7.2",
+        "v3-infinite-loading": "^1.3.2",
         "vue": "^3.5.39",
         "vue-filepond": "^8.0.0",
-        "vue-infinite-loading": "^2.4.5",
         "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
         "vue-router": "^4.6.4",
         "vuedraggable": "^4.1.0",
@@ -5330,6 +5330,12 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/v3-infinite-loading": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/v3-infinite-loading/-/v3-infinite-loading-1.3.2.tgz",
+      "integrity": "sha512-2Bg8X8nqd9tKEOJdITABtuX2BMSYo/t+eZOAD+9/xz0fGyGDclglmWjo9Zs4dr/T63liO7EniBAunBesM2QhBA==",
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
@@ -5491,15 +5497,6 @@
       "peerDependencies": {
         "filepond": ">=4.7.4 < 5.x",
         "vue": ">=3 < 4"
-      }
-    },
-    "node_modules/vue-infinite-loading": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/vue-infinite-loading/-/vue-infinite-loading-2.4.5.tgz",
-      "integrity": "sha512-xhq95Mxun060bRnsOoLE2Be6BR7jYwuC89kDe18+GmCLVrRA/dU0jrGb12Xu6NjmKs+iTW0AA6saSEmEW4cR7g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": "^2.6.10"
       }
     },
     "node_modules/vue-native-websocket": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
         "vue-router": "^4.6.4",
         "vue2-debounce": "^1.0.1",
-        "vuedraggable": "^2.24.3",
+        "vuedraggable": "^4.1.0",
         "vuex": "^4.1.0"
       },
       "devDependencies": {
@@ -4986,9 +4986,9 @@
       }
     },
     "node_modules/sortablejs": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
-      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {
@@ -5581,12 +5581,15 @@
       }
     },
     "node_modules/vuedraggable": {
-      "version": "2.24.3",
-      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
-      "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
       "license": "MIT",
       "dependencies": {
-        "sortablejs": "1.10.2"
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/vuex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "v3-infinite-loading": "^1.3.2",
         "vue": "^3.5.39",
         "vue-filepond": "^8.0.0",
-        "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
         "vue-router": "^4.6.4",
         "vuedraggable": "^4.1.0",
         "vuex": "^4.1.0"
@@ -5498,11 +5497,6 @@
         "filepond": ">=4.7.4 < 5.x",
         "vue": ">=3 < 4"
       }
-    },
-    "node_modules/vue-native-websocket": {
-      "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/nathantsoi/vue-native-websocket.git#a265da66e9fd37d8844016bad20f8902b08e00f5",
-      "license": "MIT"
     },
     "node_modules/vue-router": {
       "version": "4.6.4",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "node-vincenty": "0.0.6",
     "photoswipe": "^4.1.3",
     "proj4": "^2.7.2",
+    "v3-infinite-loading": "^1.3.2",
     "vue": "^3.5.39",
     "vue-filepond": "^8.0.0",
-    "vue-infinite-loading": "^2.4.5",
     "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
     "vue-router": "^4.6.4",
     "vuedraggable": "^4.1.0",
@@ -54,11 +54,6 @@
     "sass": "^1.77.0",
     "vite": "^6.3.5",
     "vite-plugin-eslint": "^1.8.1"
-  },
-  "overrides": {
-    "vue-infinite-loading": {
-      "vue": "$vue"
-    }
   },
   "browserslist": [
     "> 1%",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "v3-infinite-loading": "^1.3.2",
     "vue": "^3.5.39",
     "vue-filepond": "^8.0.0",
-    "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
     "vue-router": "^4.6.4",
     "vuedraggable": "^4.1.0",
     "vuex": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
     "vue-router": "^4.6.4",
     "vue2-debounce": "^1.0.1",
-    "vuedraggable": "^2.24.3",
+    "vuedraggable": "^4.1.0",
     "vuex": "^4.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "photoswipe": "^4.1.3",
     "proj4": "^2.7.2",
     "vue": "^3.5.39",
-    "vue-clipboard2": "^0.3.1",
     "vue-filepond": "^8.0.0",
     "vue-infinite-loading": "^2.4.5",
     "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "vue-infinite-loading": "^2.4.5",
     "vue-native-websocket": "github:nathantsoi/vue-native-websocket#a265da6",
     "vue-router": "^4.6.4",
-    "vue2-debounce": "^1.0.1",
     "vuedraggable": "^4.1.0",
     "vuex": "^4.1.0"
   },
@@ -58,9 +57,6 @@
   },
   "overrides": {
     "vue-infinite-loading": {
-      "vue": "$vue"
-    },
-    "vue2-debounce": {
       "vue": "$vue"
     }
   },

--- a/src/components/CardPagination.vue
+++ b/src/components/CardPagination.vue
@@ -4,15 +4,15 @@
     <div v-for="(row, index) in pageData" :key="row[rowKey]">
       <slot :row="row" :prevRow="(index > 0 ? pageData[index-1] : null)"></slot>
     </div>
-    <infinite-loading v-if="infinite" :identifier="infiniteIdentifier" @infinite="infiniteHandler">
-      <template v-slot:no-more><div></div></template>
-      <template v-slot:no-results><div></div></template>
+    <infinite-loading v-if="infinite" :identifier="infiniteIdentifier" :distance="100" @infinite="infiniteHandler">
+      <template v-slot:complete><div></div></template>
     </infinite-loading>
   </div>
 </template>
 
 <script>
-import InfiniteLoading from 'vue-infinite-loading'
+import InfiniteLoading from 'v3-infinite-loading'
+import 'v3-infinite-loading/lib/style.css'
 
 export default {
   name: 'CardPagination',

--- a/src/components/Coordinates.vue
+++ b/src/components/Coordinates.vue
@@ -15,7 +15,7 @@
           </b-dropdown>
         </p>
         <p class="control">
-          <b-button type="is-info" outlined size="is-small" v-clipboard:copy="latitude + ',' + longitude" v-clipboard:success="onCopySuccess" v-clipboard:error="onCopyError">Copy</b-button>
+          <b-button type="is-info" outlined size="is-small" @click="copyCoordinates">Copy</b-button>
         </p>
         <p v-if="haveAz" class="control">
           <b-dropdown>
@@ -91,6 +91,26 @@ export default {
     }
   },
   methods: {
+    copyCoordinates () {
+      const text = this.latitude + ',' + this.longitude
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(this.onCopySuccess, this.onCopyError)
+      } else {
+        // Fallback for non-secure contexts (navigator.clipboard requires HTTPS or localhost)
+        try {
+          const textarea = document.createElement('textarea')
+          textarea.value = text
+          textarea.style.position = 'fixed'
+          document.body.appendChild(textarea)
+          textarea.select()
+          const ok = document.execCommand('copy')
+          document.body.removeChild(textarea)
+          ok ? this.onCopySuccess() : this.onCopyError()
+        } catch (e) {
+          this.onCopyError()
+        }
+      }
+    },
     onCopySuccess () {
       this.$buefy.toast.open({
         message: 'Coordinates copied to clipboard',

--- a/src/components/MapWebcams.vue
+++ b/src/components/MapWebcams.vue
@@ -7,7 +7,7 @@
 <script>
 import MapWebcam from '../components/MapWebcam.vue'
 import axios from 'axios'
-import { debounce } from 'vue2-debounce'
+import { debounce } from '../debounce'
 
 export default {
   name: 'MapWebcams',
@@ -61,7 +61,7 @@ export default {
         this.map.off('idle', this.idleListener)
       }
 
-      // Create a debounced version of loadWebcams using vue2-debounce
+      // Create a debounced version of loadWebcams
       this.idleListener = debounce(() => {
         this.loadWebcams()
       }, 300)

--- a/src/components/PictureSwipe.vue
+++ b/src/components/PictureSwipe.vue
@@ -1,20 +1,22 @@
 <template>
   <div>
     <div ref="container">
-      <draggable v-model="myItems" handle=".handle" @change="dragChange">
-        <figure v-for="(item, index) in myItems" :key="item.src">
-          <a :href="item.src" :title="item.thumbTitle" @click.prevent="open(index)" @mouseover="$emit('mouseoverPicture', item, index)" @mouseleave="$emit('mouseleavePicture', item, index)">
-            <img :src="item.msrc" :width="thumbSize(item).w" :height="thumbSize(item).h" />
-          </a>
-          <div class="move-button" v-if="item.editable">
-            <b-button class="control handle" size="is-small" icon-left="arrows-alt" title="Drag to reorder"></b-button>
-          </div>
-          <div class="edit-buttons" v-if="item.editable">
-            <b-button class="control" size="is-small" icon-left="edit" @click="$emit('editPicture', item, index)" title="Edit"></b-button>
-            <b-button class="control" size="is-small" type="is-danger" icon-left="trash-alt" @click="$emit('deletePicture', item, index)" title="Delete"></b-button>
-          </div>
-          <font-awesome-icon v-if="item.thumbTitle" class="comment-icon" :icon="['far', 'comment']" />
-        </figure>
+      <draggable v-model="myItems" item-key="src" handle=".handle" @change="dragChange">
+        <template #item="{ element: item, index }">
+          <figure>
+            <a :href="item.src" :title="item.thumbTitle" @click.prevent="open(index)" @mouseover="$emit('mouseoverPicture', item, index)" @mouseleave="$emit('mouseleavePicture', item, index)">
+              <img :src="item.msrc" :width="thumbSize(item).w" :height="thumbSize(item).h" />
+            </a>
+            <div class="move-button" v-if="item.editable">
+              <b-button class="control handle" size="is-small" icon-left="arrows-alt" title="Drag to reorder"></b-button>
+            </div>
+            <div class="edit-buttons" v-if="item.editable">
+              <b-button class="control" size="is-small" icon-left="edit" @click="$emit('editPicture', item, index)" title="Edit"></b-button>
+              <b-button class="control" size="is-small" type="is-danger" icon-left="trash-alt" @click="$emit('deletePicture', item, index)" title="Delete"></b-button>
+            </div>
+            <font-awesome-icon v-if="item.thumbTitle" class="comment-icon" :icon="['far', 'comment']" />
+          </figure>
+        </template>
       </draggable>
     </div>
 

--- a/src/components/SearchField.vue
+++ b/src/components/SearchField.vue
@@ -15,8 +15,6 @@
       icon="search"
       rounded
       clearable
-      v-debounce:300ms="onInput"
-      :debounce-events="'input'"
       @select="onSelect"
       @focus="searchFocus"
       @blur="searchBlur"
@@ -74,6 +72,7 @@ import axios from 'axios'
 import utils from '../mixins/utils.js'
 import haversine from 'haversine-distance'
 import geonames from '../mixins/geonames.js'
+import { debounce } from '../debounce'
 
 const MIN_QUERY_LENGTH = 4
 const COORDINATE_REGEX = /^\s*(-?[0-9.]+)\s*,\s*(-?[0-9.]+)\s*$/
@@ -108,6 +107,14 @@ export default {
     showNoResults () {
       return this.myQuery && this.myQuery.length >= MIN_QUERY_LENGTH && this.autocompleteResults.length === 0 && !this.isLoading
     }
+  },
+  watch: {
+    myQuery (value) {
+      this.debouncedOnInput(value)
+    }
+  },
+  created () {
+    this.debouncedOnInput = debounce(this.onInput, 300)
   },
   methods: {
     searchFocus () {

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,0 +1,11 @@
+// Minimal replacement for vue2-debounce's `debounce` export (Vue 2-only package).
+// Framework-agnostic: setTimeout/clearTimeout only, no Vue APIs involved.
+export function debounce (fn, wait) {
+  let timer = null
+  function debounced (...args) {
+    clearTimeout(timer)
+    timer = setTimeout(() => fn(...args), wait)
+  }
+  debounced.cancel = () => clearTimeout(timer)
+  return debounced
+}

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@ import App from './App.vue'
 import router from './router'
 import Buefy from 'buefy'
 // import vueDebounce from 'vue2-debounce'
-// import VueClipboard from 'vue-clipboard2'
 import MatchMedia from './matchmedia'
 import VueKeyCloak from '@dsb-norge/vue-keycloak-js'
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -39,10 +38,9 @@ library.add(faWikipediaW, faGoogle, faGithub)
 const app = createApp(App)
 app.component('font-awesome-icon', FontAwesomeIcon)
 app.component('font-awesome-layers', FontAwesomeLayers)
-// vue2-debounce and vue-clipboard2 are Vue 2-only (v-debounce/v-clipboard directives
-// are temporarily unavailable, silently no-op in templates) until replaced (Phase 4).
+// vue2-debounce is Vue 2-only (v-debounce directive is temporarily unavailable,
+// silently no-op in templates) until replaced (Phase 4).
 // app.use(vueDebounce)
-// app.use(VueClipboard)
 app.use(Buefy, {
   defaultIconComponent: 'font-awesome-icon',
   defaultIconPack: 'far'

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import Buefy from 'buefy'
-// import vueDebounce from 'vue2-debounce'
 import MatchMedia from './matchmedia'
 import VueKeyCloak from '@dsb-norge/vue-keycloak-js'
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -38,9 +37,6 @@ library.add(faWikipediaW, faGoogle, faGithub)
 const app = createApp(App)
 app.component('font-awesome-icon', FontAwesomeIcon)
 app.component('font-awesome-layers', FontAwesomeLayers)
-// vue2-debounce is Vue 2-only (v-debounce directive is temporarily unavailable,
-// silently no-op in templates) until replaced (Phase 4).
-// app.use(vueDebounce)
 app.use(Buefy, {
   defaultIconComponent: 'font-awesome-icon',
   defaultIconPack: 'far'

--- a/src/store.js
+++ b/src/store.js
@@ -2,10 +2,8 @@ import { createStore } from 'vuex'
 import EventBus from './event-bus'
 import { decompressKeys } from './keyzipper'
 import axios from 'axios'
+import { connectWebSocket } from './websocket'
 
-// vue-native-websocket install() is Vue 2-only (relies on Vue.use/Vue.mixin) and
-// isn't called here until it's replaced with a Vue 3-compatible package (Phase 4).
-// Live spot updates over WebSocket are temporarily unavailable until then.
 let socket = null
 
 const MAX_SPOT_AGE = 86400000
@@ -227,7 +225,6 @@ function loadAlerts (noCache) {
 loadAlerts(false)
 setInterval(loadAlerts, ALERT_UPDATE_INTERVAL)
 
-// WebSocket connection setup (vue-native-websocket) is temporarily disabled,
-// see the `socket` variable comment above.
+connectWebSocket(import.meta.env.VITE_WSS_URL + '/ws', store, { reconnectionDelay: 1000 })
 
 export default store

--- a/src/views/Activators.vue
+++ b/src/views/Activators.vue
@@ -6,7 +6,7 @@
       <section class="section">
         <div class="container">
           <b-field>
-            <FilterInput v-model="filter" ref="filter" v-debounce:500ms="onFilterChanged" />
+            <FilterInput v-model="filter" ref="filter" @update:model-value="onFilterInput" @keyup.enter="onFilterEnter" />
           </b-field>
 
           <b-table class="auto-width" :narrowed="true" :striped="true" :data="activators" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" v-model:current-page="curPage" backend-sorting :default-sort="[sortField, sortDirection]" @sort="onSort" :mobile-cards="false">
@@ -49,6 +49,7 @@ import prefs from '../mixins/prefs.js'
 import PageLayout from '../components/PageLayout.vue'
 import FilterInput from '../components/FilterInput.vue'
 import CountryFlag from '../components/CountryFlag.vue'
+import { debounce } from '../debounce'
 
 export default {
   name: 'Activators',
@@ -76,6 +77,13 @@ export default {
     onFilterChanged () {
       this.loadData()
     },
+    onFilterInput () {
+      this.debouncedFilterChanged()
+    },
+    onFilterEnter () {
+      this.debouncedFilterChanged.cancel()
+      this.onFilterChanged()
+    },
     country (callsign) {
       return prefix.isoCodeForCallsign(callsign)
     }
@@ -95,6 +103,9 @@ export default {
         this.loadData()
       }
     }
+  },
+  created () {
+    this.debouncedFilterChanged = debounce(this.onFilterChanged, 500)
   },
   mounted () {
     document.title = 'Activators - SOTLAS'

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -1,0 +1,36 @@
+// Minimal replacement for vue-native-websocket (Vue 2-only, relies on Vue.use/Vue.mixin).
+// The app never used the plugin surface ($socket/$connect/sockets component option) —
+// only the SOCKET_* mutation convention on the store, so this reproduces just that:
+// connect, forward events as SOCKET_* commits, and auto-reconnect on close.
+export function connectWebSocket (url, store, { reconnectionDelay = 1000 } = {}) {
+  let reconnectionCount = 0
+
+  function connect () {
+    const ws = new WebSocket(url)
+    // Matches the `format: 'json'` option of vue-native-websocket; SOCKET_ONOPEN
+    // and setRbnFilter call sendObj() on the WebSocket instance itself.
+    ws.sendObj = (obj) => ws.send(JSON.stringify(obj))
+
+    ws.onopen = (event) => {
+      reconnectionCount = 0
+      store.commit('SOCKET_ONOPEN', event)
+    }
+    ws.onerror = (event) => {
+      store.commit('SOCKET_ONERROR', event)
+    }
+    ws.onmessage = (event) => {
+      store.commit('SOCKET_ONMESSAGE', JSON.parse(event.data))
+    }
+    ws.onclose = (event) => {
+      store.commit('SOCKET_ONCLOSE', event)
+      // Reconnect unconditionally, same as the original reconnection:true/reconnectionAttempts:Infinity.
+      reconnectionCount++
+      setTimeout(() => {
+        store.commit('SOCKET_RECONNECT', reconnectionCount)
+        connect()
+      }, reconnectionDelay)
+    }
+  }
+
+  connect()
+}


### PR DESCRIPTION
As discussed in #44, this is Phase 4 of the Vue 3 migration, against the `vue3` branch (following #45, #46). It replaces the five remaining Vue 2-only libraries so the features they backed work again under Vue 3. One concern per commit.

**What changed:**

- **vuedraggable 2 → 4** — v2 references `$scopedSlots` and crashed every summit page that has photos. v4 keeps the `v-model`/`handle`/`@change` contract; only the slot syntax changes (`<template #item>` + `item-key`).
- **vue-clipboard2 → `navigator.clipboard`** — the directive uses Vue 2 hook names (`bind`/`unbind`) and silently stopped working. The coordinates Copy button now calls `navigator.clipboard.writeText()` with a textarea/`execCommand` fallback for non-secure contexts. The dependency is dropped (it was used in a single place).
- **vue2-debounce → in-repo `src/debounce.js`** — the `v-debounce` directive reads `vnode.data.attrs` (Vue 2 vnode shape), so the NavBar search and the Activators filter had stopped firing. Replaced with a small debounce helper: SearchField debounces a `myQuery` watcher (covers paste as well as typing), Activators debounces the `update:model-value` event (so restoring the saved filter from localStorage doesn't fire a duplicate request), and Enter still searches immediately in both places.
  - Why not the maintained successor `vue-debounce` v5: Buefy 3's `b-autocomplete`/`b-input` set `inheritAttrs: false`, so the `debounce-events` attribute never reaches the directive and it silently falls back to `keyup`, which would break paste-driven searches. Rather than work around that, the two call sites were rewritten without a directive.
- **vue-infinite-loading → v3-infinite-loading** — the old library uses `$on`/`destroyed`/array-shaped `$slots` and crashes at runtime under Vue 3, breaking the mobile card infinite scroll. The new one keeps the `identifier`/`$state.loaded()`/`$state.complete()` contract, so `CardPagination`'s handler is unchanged; `distance=100` preserves the old 100px prefetch. The npm `overrides` block became empty with this change and is removed.
- **vue-native-websocket → in-repo `src/websocket.js`** — its `install()` is Vue 2-only, so live spot updates had been disabled since Phase 1. The app only ever used the `SOCKET_*` store mutation convention (no `$socket`/`$connect`/`sockets` option), so a ~35-line module reproduces exactly that: connect, `sendObj()` on the WebSocket instance, `SOCKET_*` commits, fixed 1 s reconnection — same semantics as the previous `reconnection: true, reconnectionDelay: 1000` setup. Store mutations are untouched. This also removes a GitHub-pinned dependency.

The `@dsb-norge/vue-keycloak-js` fork (`#sotlas3`) already supports Vue 2 and 3 (v2.4.0 branches inside `install()`), so it needed no changes.

Net dependency count: −4, +1 (`v3-infinite-loading`).

**Review notes:**

- Compare: https://github.com/manuelkasper/sotlas-frontend/compare/vue3...jj1xgo:sotlas-frontend:vue3-phase4
- `npm ci`, `npm run lint` (zero warnings), and `npm run build` pass on this branch standalone
- Verified in a headless browser: Copy button toast (both the clipboard API and the fallback path), a single debounced request per typing pause (500 ms filter / 300 ms search), Enter firing immediately, mobile infinite scroll on the alerts and activator pages (batches load, no stray "No more results!" text), and a live WebSocket connection against `wss://sotl.as/api/ws` with the full spot list received and the RBN filter round-trip working
- Verified again in a real browser: all of the above end to end, including the actual clipboard contents, filter/search behaviour, infinite scroll to the end of the list, and the live feed indicator showing connected

After this, Phase 5 (final cleanup: remaining `$parent`/`$root`/`$on` usages, eslint vue3 rules, full page-by-page checklist pass) is the last planned phase.