### PR TITLE
Vue 3 migration - Phase 5 (final pass)

### DIFF
--- a/src/components/AlertsList.vue
+++ b/src/components/AlertsList.vue
@@ -69,11 +69,11 @@
         </b-select>
       </template>
     </b-table>
-    <b-modal v-if="isEditAlertActive" :active="true" has-modal-card :can-cancel="['escape']" @close="isEditAlertActive = false">
-      <EditAlert :alert="alertToEdit" />
+    <b-modal v-model="isEditAlertActive" has-modal-card :can-cancel="['escape']">
+      <EditAlert :alert="alertToEdit" @close="isEditAlertActive = false" />
     </b-modal>
-    <b-modal v-if="isEditSpotActive" :active="true" has-modal-card :can-cancel="['escape']" @close="isEditSpotActive = false">
-      <EditSpot :spot="spotToMake" />
+    <b-modal v-model="isEditSpotActive" has-modal-card :can-cancel="['escape']">
+      <EditSpot :spot="spotToMake" @close="isEditSpotActive = false" />
     </b-modal>
   </div>
 </template>

--- a/src/components/BasemapAtInfo.vue
+++ b/src/components/BasemapAtInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal v-model="active" :on-cancel="cancelInfo" :can-cancel="false">
+  <b-modal v-model="active" :can-cancel="false">
     <div class="box content">
       <div class="has-text-centered">
         <span class="fp at flag"></span>

--- a/src/components/BasemapAtInfo.vue
+++ b/src/components/BasemapAtInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal v-model:active="active" :on-cancel="cancelInfo" :can-cancel="false">
+  <b-modal v-model="active" :on-cancel="cancelInfo" :can-cancel="false">
     <div class="box content">
       <div class="has-text-centered">
         <span class="fp at flag"></span>

--- a/src/components/CardPagination.vue
+++ b/src/components/CardPagination.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card-list">
-    <b-pagination v-if="paginated && !infinite" :total="data.length" v-model:current="currentCardPage" :simple="true" size="is-small" :per-page="perPage" aria-next-label="Next page" aria-previous-label="Previous page" aria-page-label="Page" aria-current-label="Current page" />
+    <b-pagination v-if="paginated && !infinite" :total="data.length" v-model="currentCardPage" :simple="true" size="is-small" :per-page="perPage" aria-next-label="Next page" aria-previous-label="Previous page" aria-page-label="Page" aria-current-label="Current page" />
     <div v-for="(row, index) in pageData" :key="row[rowKey]">
       <slot :row="row" :prevRow="(index > 0 ? pageData[index-1] : null)"></slot>
     </div>

--- a/src/components/EditAlert.vue
+++ b/src/components/EditAlert.vue
@@ -34,7 +34,7 @@
       </b-field>
 
       <b-field label="Frequency-Mode(s)">
-        <b-taginput v-model="freqMode" ref="freqMode" autocomplete rounded :data="freqModeSuggestions" :confirm-key-codes="[9,13,32,188]" @typing="updateFreqModeSuggestions" @update:model-value="onFreqModeInput" @blur="onFreqModeBlur" @keydown="onFreqModeKeyDown" append-to-body />
+        <b-taginput v-model="freqMode" ref="freqMode" autocomplete rounded :data="freqModeSuggestions" :confirm-keys="freqModeConfirmKeys" @typing="updateFreqModeSuggestions" @update:model-value="onFreqModeInput" @blur="onFreqModeBlur" @keydown="onFreqModeKeyDown" append-to-body />
         <template v-slot:message>
           Format: <em>freq-mode, ...</em> (e.g. <em>7.030-cw, 14.250-ssb</em>)
         </template>
@@ -306,10 +306,10 @@ export default {
         this.$refs.freqMode.addTag()
       }, 100)
     },
-    onFreqModeKeyDown () {
+    onFreqModeKeyDown (event) {
       // Hack to allow us to get keep-first behavior on autocomplete despite the fact
       // that b-taginput sets keepFirst = !allowNew
-      if (this.$refs.freqMode.confirmKeyCodes.indexOf(event.keyCode) >= 0) {
+      if (this.freqModeConfirmKeys.indexOf(event.key) >= 0) {
         event.preventDefault()
         this.$refs.freqMode.addTag()
       }
@@ -351,6 +351,7 @@ export default {
       time: '',
       freqMode: [],
       freqModeSuggestions: [],
+      freqModeConfirmKeys: [',', 'Tab', 'Enter', ' '],
       comments: '',
       summit: null,
       summitInvalid: false,

--- a/src/components/EditAlert.vue
+++ b/src/components/EditAlert.vue
@@ -45,7 +45,7 @@
       </b-field>
     </section>
     <footer class="modal-card-foot">
-      <b-button @click="$parent.close()">Cancel</b-button>
+      <b-button @click="$emit('close')">Cancel</b-button>
       <b-button type="is-info" :disabled="!isInputValid" :loading="posting" @click="postAlert">{{ this.alert ? 'Edit' : 'Add' }} Alert</b-button>
     </footer>
   </div>
@@ -69,6 +69,7 @@ export default {
     defaultSummitCode: String,
     alert: Object
   },
+  emits: ['close'],
   prefs: {
     key: 'editAlertPrefs',
     props: ['lastCallsign', 'timeZone', 'defaultComments']
@@ -255,7 +256,7 @@ export default {
       this.postSotaWatchAlert(params)
         .then(response => {
           this.$store.dispatch('reloadAlerts')
-          this.$parent.close()
+          this.$emit('close')
         })
         .catch(err => {
           let errorText = err.message

--- a/src/components/EditPhoto.vue
+++ b/src/components/EditPhoto.vue
@@ -42,7 +42,7 @@
         </b-field>
       </section>
       <footer class="modal-card-foot">
-        <button class="button" type="button" @click="$parent.close()">Cancel</button>
+        <button class="button" type="button" @click="$emit('close')">Cancel</button>
         <button class="button is-info" :disabled="!isInputValid" :loading="saving" @click="save">Save</button>
       </footer>
   </div>
@@ -58,6 +58,7 @@ export default {
     summitCode: String,
     photo: Object
   },
+  emits: ['close', 'photoEdited'],
   mixins: [photos, api],
   computed: {
     isInputValid () {
@@ -116,7 +117,7 @@ export default {
       this.editPhoto(this.summitCode, this.photo.filename, newData)
         .then(() => {
           this.$emit('photoEdited')
-          this.$parent.close()
+          this.$emit('close')
         })
         .finally(() => {
           this.saving = false

--- a/src/components/EditSpot.vue
+++ b/src/components/EditSpot.vue
@@ -40,7 +40,7 @@
       </b-field>
     </section>
     <footer class="modal-card-foot">
-      <b-button @click="$parent.close()">Cancel</b-button>
+      <b-button @click="$emit('close')">Cancel</b-button>
       <b-button type="is-info" :disabled="!isInputValid" :loading="posting" @click="postSpot">{{ (this.spot && this.spot.id) ? 'Edit' : 'Add' }} Spot</b-button>
     </footer>
   </div>
@@ -63,6 +63,7 @@ export default {
     defaultSummitCode: String,
     spot: Object
   },
+  emits: ['close'],
   prefs: {
     key: 'spotPrefs',
     props: ['lastCallsign', 'lastSummitCode', 'defaultComments']
@@ -231,7 +232,7 @@ export default {
             type: response.data.type
           })
 
-          this.$parent.close()
+          this.$emit('close')
         })
         .catch(err => {
           let errorText = err.message

--- a/src/components/MapDraw.vue
+++ b/src/components/MapDraw.vue
@@ -7,7 +7,7 @@
         <div v-if="descent !== null" class="distance-info">↓ <DistanceLabel :distance="descent" small-units /></div>
         <b-button size="is-small" type="is-text" icon-left="window-close" @click="hideElevationProfile" />
       </div>
-      <b-loading :active="loading" :is-full-page="false" />
+      <b-loading :model-value="loading" :is-full-page="false" />
       <LineChart v-if="chartData" :data="chartData" labelField="distance" valueField="elevation" name="Elevation" :xIsSeries="true" :animate="false" :suffixX="' ' + distanceUnits" :suffixY="' ' + $store.state.altitudeUnits" />
     </div>
   </div>

--- a/src/components/MiniMap.vue
+++ b/src/components/MiniMap.vue
@@ -21,7 +21,7 @@
       <div v-if="zoomWarningVisible" class="zoom-warning">Zoom in to see all activations</div>
     </MglMap>
     <MapKeyFailedInfo v-if="mapTilerApiKeyFailed" />
-    <b-loading class="mini-map-loading" :is-full-page="false" :active="!mapStyle && !mapTilerApiKeyFailed" />
+    <b-loading class="mini-map-loading" :is-full-page="false" :model-value="!mapStyle && !mapTilerApiKeyFailed" />
   </div>
 </template>
 

--- a/src/components/ModalQSOList.vue
+++ b/src/components/ModalQSOList.vue
@@ -7,7 +7,7 @@
       </header>
       <section class="modal-card-body">
         <QSOList v-if="activationDetails !== null" :data="activationDetails.ActivatorLogs" />
-        <b-loading :is-full-page="false" :active="activationLoading" />
+        <b-loading :is-full-page="false" :model-value="activationLoading" />
       </section>
       <footer class="modal-card-foot"></footer>
     </div>

--- a/src/components/ModalQSOList.vue
+++ b/src/components/ModalQSOList.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal v-model:active="modalActive" :can-cancel="['escape', 'outside']" has-modal-card>
+  <b-modal v-model="modalActive" :can-cancel="['escape', 'outside']" has-modal-card>
     <div class="modal-card">
       <header class="modal-card-head">
         <p class="modal-card-title"><span v-if="activationDetails"><router-link :to="makeActivatorLinkUserId(activationDetails.UserID)">{{ activationDetails.OwnCallsign }}</router-link> on <router-link :to="makeSummitLink(summitCode)">{{ activationDetails.Summit }}</router-link>, <span class="activation-date">{{ niceActivationDate }}</span></span></p>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-navbar wrapper-class="container" :class="{ 'search-focused': searchFocused }" :fixed-top="true" :close-on-click="false" v-model:isActive="burgerActive">
+  <b-navbar wrapper-class="container" :class="{ 'search-focused': searchFocused }" :fixed-top="true" :close-on-click="false" v-model="burgerActive">
     <template #brand>
       <b-navbar-item tag="router-link" to="/about">
         <img v-if="$mq.widescreen" src="../assets/sotlas.svg" alt="Logo">

--- a/src/components/ResourceList.vue
+++ b/src/components/ResourceList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="content">
     <ul class="resources">
-      <li v-for="resource in resources" :key="resource.id"><b-icon v-if="resource.icon" :icon="resource.icon" :pack="resource.iconPack" size="is-small" /><svgicon v-if="resource.svgicon" class="icon" :icon="resource.svgicon" color="#555" /><img v-if="resource.iconImg" class="icon" :src="resource.iconImg" />{{ resource.prefix ? resource.prefix + ': ' : '' }}<a :href="resource.url" target="_blank">{{ resource.title }}</a><span class="subdued author" v-if="resource.author">(by {{ resource.author }} on {{ formatSubmittedDate(resource.date) }})</span><span v-if="resource.suffix" class="subdued details">{{ resource.suffix }}</span></li>
+      <li v-for="resource in resources" :key="resource.id"><b-icon v-if="resource.icon" :icon="resource.icon" :pack="resource.iconPack" size="is-small" /><img v-if="resource.iconImg" class="icon" :src="resource.iconImg" />{{ resource.prefix ? resource.prefix + ': ' : '' }}<a :href="resource.url" target="_blank">{{ resource.title }}</a><span class="subdued author" v-if="resource.author">(by {{ resource.author }} on {{ formatSubmittedDate(resource.date) }})</span><span v-if="resource.suffix" class="subdued details">{{ resource.suffix }}</span></li>
     </ul>
   </div>
 </template>

--- a/src/components/SpotsList.vue
+++ b/src/components/SpotsList.vue
@@ -71,8 +71,8 @@
         </b-select>
       </template>
     </b-table>
-    <b-modal v-if="isEditSpotActive" :active="true" has-modal-card :can-cancel="['escape']" @close="isEditSpotActive = false">
-      <EditSpot :spot="spotToEdit" />
+    <b-modal v-model="isEditSpotActive" has-modal-card :can-cancel="['escape']">
+      <EditSpot :spot="spotToEdit" @close="isEditSpotActive = false" />
     </b-modal>
   </div>
 </template>

--- a/src/components/SummitPhotos.vue
+++ b/src/components/SummitPhotos.vue
@@ -12,8 +12,8 @@
         </template>
       </SummitPhotosGroup>
     </div>
-    <b-modal v-model:active="isEditorActive" has-modal-card trap-focus aria-role="dialog" aria-modal>
-      <EditPhoto v-if="editingPhoto" :photo="editingPhoto" :summitCode="summit.code" @photoEdited="$emit('photoEdited')" />
+    <b-modal v-model="isEditorActive" has-modal-card trap-focus aria-role="dialog" aria-modal>
+      <EditPhoto v-if="editingPhoto" :photo="editingPhoto" :summitCode="summit.code" @photoEdited="$emit('photoEdited')" @close="isEditorActive = false" />
     </b-modal>
   </div>
 </template>

--- a/src/components/SummitPopup.vue
+++ b/src/components/SummitPopup.vue
@@ -1,5 +1,5 @@
 <template>
-  <MglPopup v-if="summit" key="summitinfo" :coordinates="[summit.coordinates.longitude, summit.coordinates.latitude]" anchor="bottom" :closeButton="false" :focusAfterOpen="false" @close="$emit('close')">
+  <MglPopup v-if="summit" key="summitinfo" :coordinates="[summit.coordinates.longitude, summit.coordinates.latitude]" anchor="bottom" :closeButton="false" :focusAfterOpen="false" :max-width="maxWidth" @close="$emit('close')">
     <div :class="{ summitPopup: true, minimize: minimizePopup }">
       <div v-if="coverPhoto" class="photo">
         <div style="text-align: center"><a :href="coverPhoto.mediaLink" target="_blank"><img :src="coverPhoto.src" /></a></div>
@@ -38,7 +38,8 @@ export default {
   props: {
     summit: Object,
     lastSpot: Object,
-    nextAlert: Object
+    nextAlert: Object,
+    maxWidth: String
   },
   mixins: [utils, coverphoto],
   components: {

--- a/src/components/SummitVideosGroup.vue
+++ b/src/components/SummitVideosGroup.vue
@@ -4,7 +4,7 @@
       <router-link v-if="titleLink" :to="titleLink">{{ title }}</router-link>
       <span v-else>{{ title }}</span>
     </div>
-    <LazyYoutubeVideo v-for="video in videos" :key="video.src" :src="video.src" previewImageSize="hqdefault" :webp="false" />
+    <LazyYoutubeVideo v-for="video in videos" :key="video.src" :src="video.src" previewImageSize="hqdefault" />
   </div>
 </template>
 

--- a/src/components/SwisstopoInfo.vue
+++ b/src/components/SwisstopoInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal v-model:active="active" :on-cancel="cancelInfo" :can-cancel="false">
+  <b-modal v-model="active" :on-cancel="cancelInfo" :can-cancel="false">
     <div class="box content">
       <div class="has-text-centered">
         <span class="fp ch flag"></span>

--- a/src/components/SwisstopoInfo.vue
+++ b/src/components/SwisstopoInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal v-model="active" :on-cancel="cancelInfo" :can-cancel="false">
+  <b-modal v-model="active" :can-cancel="false">
     <div class="box content">
       <div class="has-text-centered">
         <span class="fp ch flag"></span>

--- a/src/mapgl/README.md
+++ b/src/mapgl/README.md
@@ -67,9 +67,12 @@ on the SDK directly.
 - **Control prop reactivity** (`controls.js`): unlike
   `@indoorequal/vue-maplibre-gl`'s `useControl` (which reads props once at
   creation), this module's `useControl` deep-watches the full props object
-  and removes+recreates the control on any change. This is what let SOTLAS
-  drop its `:key="$mq.mobile"` remount workaround for
-  `MglAttributionControl`.
+  and removes+recreates the control on any change (e.g. so
+  `MglAttributionControl`'s `compact` prop tracks `$mq.mobile` across resizes
+  without a `:key` remount). This does NOT change `AttributionControl`'s
+  compact-on-load behavior — maplibre-gl always pairs the `compact` class
+  with `compact-show` on (re)creation, so the control still renders expanded
+  until the map is dragged or the control is clicked, same as upstream.
 
 ## 4. SDK behaviors we explicitly suppress or rely on
 

--- a/src/mapgl/controls.js
+++ b/src/mapgl/controls.js
@@ -3,10 +3,16 @@ import { AttributionControl, GeolocateControl, NavigationControl, ScaleControl }
 import { isInitializedSymbol, mapSymbol } from './keys.js'
 
 // @indoorequal/vue-maplibre-gl's useControl only evaluates props once at
-// creation (no prop watcher besides position), which is why SOTLAS had to
-// work around AttributionControl's compact mode with a `:key="$mq.mobile"`
-// remount. Here we watch the full props object and remove+recreate the
-// control on any change, so callers don't need that workaround.
+// creation (no prop watcher besides position). This migration branch briefly
+// worked around that with a `:key="$mq.mobile"` remount on
+// MglAttributionControl (added in 5956f8c, removed once this module replaced
+// vue-maplibre-gl in ba3b689) — that workaround never existed upstream. Here
+// we watch the full props object and remove+recreate the control on any
+// change, which is a real improvement over evaluating props once (e.g. for
+// resize-driven prop changes), but it does NOT make AttributionControl's
+// compact mode collapse on load: maplibre-gl always pairs the `compact`
+// class with `compact-show` on (re)creation, so the control renders expanded
+// until the user drags the map or clicks it, matching upstream's behavior.
 function useControl (createControl, props) {
   const map = inject(mapSymbol)
   const isInitialized = inject(isInitializedSymbol)

--- a/src/views/Activator.vue
+++ b/src/views/Activator.vue
@@ -33,7 +33,7 @@
           </div>
 
           <SpotsList v-if="recentSpots.length > 0" class="auto-width" :data="recentSpots" :callsignLink="false" :paginated="recentSpots.length > 10" />
-          <p v-else-if="$store.state.spots.length === 0"><b-loading :active="true" :is-full-page="false" />Loading...</p>
+          <p v-else-if="$store.state.spots.length === 0"><b-loading :model-value="true" :is-full-page="false" />Loading...</p>
         </div>
       </section>
 
@@ -49,7 +49,7 @@
           </div>
 
           <RBNSpotsList v-if="rbnSpots !== null && rbnSpots.length > 0" class="auto-width" :data="rbnSpots" :callsignLink="false" :paginated="rbnSpots.length > 10" />
-          <p v-else-if="rbnSpots === null"><b-loading :active="true" :is-full-page="false" />Loading...</p>
+          <p v-else-if="rbnSpots === null"><b-loading :model-value="true" :is-full-page="false" />Loading...</p>
         </div>
       </section>
 
@@ -67,7 +67,7 @@
         <section class="section">
           <div class="container">
             <ActivationCharts v-if="activations.length > 0" :activations="activations" />
-            <p class="loading-charts" v-else-if="activationsLoading"><b-loading :active="true" :is-full-page="false" /><font-awesome-icon :icon="['far', 'chart-bar']" /></p>
+            <p class="loading-charts" v-else-if="activationsLoading"><b-loading :model-value="true" :is-full-page="false" /><font-awesome-icon :icon="['far', 'chart-bar']" /></p>
           </div>
         </section>
 
@@ -98,7 +98,7 @@
             No activations found.
           </b-message>
 
-          <p v-if="activationsLoading"><b-loading :active="true" :is-full-page="false" />Loading...</p>
+          <p v-if="activationsLoading"><b-loading :model-value="true" :is-full-page="false" />Loading...</p>
         </div>
       </section>
     </template>

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -34,7 +34,7 @@
     <SwisstopoInfo />
     <BasemapAtInfo />
     <MapKeyFailedInfo v-if="mapTilerApiKeyFailed" />
-    <b-loading :is-full-page="false" :active="(filtering || !showMap || !mapStyle) && !mapTilerApiKeyFailed" />
+    <b-loading :is-full-page="false" :model-value="(filtering || !showMap || !mapStyle) && !mapTilerApiKeyFailed" />
   </div>
 </template>
 

--- a/src/views/RBNSpots.vue
+++ b/src/views/RBNSpots.vue
@@ -50,7 +50,7 @@
     </div>
 
     <RBNSpotsList v-if="!loading && filteredSpots.length > 0" :data="filteredSpots" :infinite="true" />
-    <b-loading :active="loading" :is-full-page="false" />
+    <b-loading :model-value="loading" :is-full-page="false" />
 
     <p v-if="!loading && filteredSpots.length === 0">No matching spots found.</p>
 

--- a/src/views/SotaSpots.vue
+++ b/src/views/SotaSpots.vue
@@ -44,7 +44,7 @@
     </div>
 
     <SpotsList v-if="filteredSpots.length > 0" :data="filteredSpots" :infinite="true" />
-    <b-loading v-if="$store.state.spots.length === 0" :active="true" :is-full-page="false" />
+    <b-loading v-if="$store.state.spots.length === 0" :model-value="true" :is-full-page="false" />
 
     <p v-else-if="filteredSpots.length === 0">No matching spots found.</p>
   </div>

--- a/src/views/Spots.vue
+++ b/src/views/Spots.vue
@@ -20,8 +20,8 @@
           <router-view />
         </div>
 
-        <b-modal v-if="isEditSpotActive" :active="true" has-modal-card :can-cancel="['escape']" @close="isEditSpotActive = false">
-          <EditSpot />
+        <b-modal v-model="isEditSpotActive" has-modal-card :can-cancel="['escape']">
+          <EditSpot @close="isEditSpotActive = false" />
         </b-modal>
       </section>
     </template>

--- a/src/views/Summit.vue
+++ b/src/views/Summit.vue
@@ -122,11 +122,11 @@
 
     <SummitActivations :summitCode="summitCode" :activations="activations" :myActivations="myActivations" :myChases="myChases" />
 
-    <b-modal v-if="isAddAlertActive" :active="true" has-modal-card :can-cancel="['escape']" @close="isAddAlertActive = false">
-      <EditAlert :defaultSummitCode="summitCode" />
+    <b-modal v-model="isAddAlertActive" has-modal-card :can-cancel="['escape']">
+      <EditAlert :defaultSummitCode="summitCode" @close="isAddAlertActive = false" />
     </b-modal>
-    <b-modal v-if="isAddSpotActive" :active="true" has-modal-card :can-cancel="['escape']" @close="isAddSpotActive = false">
-      <EditSpot :defaultSummitCode="summitCode" />
+    <b-modal v-model="isAddSpotActive" has-modal-card :can-cancel="['escape']">
+      <EditSpot :defaultSummitCode="summitCode" @close="isAddSpotActive = false" />
     </b-modal>
   </SummitDatabasePageLayout>
 </template>


### PR DESCRIPTION
As discussed in #44, this is Phase 5 (final pass) of the Vue 3 migration, against the `vue3` branch (following #45, #46, #47). This closes out the migration plan: the remaining `<b-modal>` v-model breakage, a mechanical audit for other leftover Buefy 3 prop breakage of the same shape, and a full page-by-page checklist pass. One concern per commit.

**What changed:**

- **Broken `v-model` on `<b-modal>` (all 10 usages)** — Buefy 3 renamed the modal's visibility prop from `active` to `modelValue`; every `<b-modal :active="...">` in the codebase was silently binding to a prop that no longer exists, so modals compiled and rendered without error but never opened. Replaced with `v-model`, and `this.$parent.close()` calls (which depended on the old parent-controlled pattern) with the modal's own close mechanism.
- **Mechanical prop-fallthrough audit** — built a small toolchain to catch the same class of bug elsewhere: extract every Buefy component's real props/emits from the running app (mixins resolved), parse all `.vue` templates with `@vue/compiler-sfc` into ASTs, and cross-reference. This caught five more instances of the same "renamed/removed prop, no build or console error" pattern:
  - `<b-loading :active>` (10 places) — prop is `model-value`; loading spinners never appeared.
  - `NavBar.vue` `v-model:isActive` — burger menu never closed after tapping a nav link on mobile.
  - `CardPagination.vue` `v-model:current` — mobile card pagination was unresponsive.
  - `EditAlert.vue` `:confirm-key-codes` — Taginput's confirm-key API changed shape in Buefy 3 (now `confirm-keys` + key-name strings), causing a `TypeError` on every keystroke in the Frequency/Mode field.
  - `Map.vue`'s `max-width` on `<SummitPopup>` wasn't forwarded to the underlying popup, so it stayed at the library default instead of the intended 600px.
  - A few harmless leftover props with no live effect were also removed as dead code.
- **Unused `svgicon` tag removed** — leftover from the pre-Vite build, printing a Vue 3 console warning on every page.

**Review notes:**

- Compare: https://github.com/manuelkasper/sotlas-frontend/compare/vue3...jj1xgo:sotlas-frontend:vue3-phase5
- `npm ci`, `npm run lint` (zero warnings), and `npm run build` pass on this branch standalone
- Verified in a headless browser (full page-by-page pass against the Phase 0 checklist): all 21 routes, global nav/search/footer elements, and the map/summit detail sub-components render and behave as expected, including the fixes above (modals open/close, loading spinners appear, burger menu closes, pagination responds, tag input accepts keys, popup width applies)
- A handful of items require the `sotl.as` domain to test (SSO only works there): login/logout, the real Turnstile flow, QSO list access, the frequency/tag-input forms in Edit Spot/Edit Alert, and photo upload. I'll verify these against the deployed preview and report back in #44.

This completes all five planned phases of the migration.