### PR TITLE
Fix cosmetic and functional regressions introduced by the Vue 3 migration

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,24 @@ export default {
 <style lang="scss">
 @use "bulma/versions/bulma-no-dark-mode";
 
+// The Vue2/Bulma 0.7 build overrode $link to $blue (hsl(217, 71%, 53%)). Bulma 1.0's
+// prebuilt "no-dark-mode" entry point doesn't support Sass `with()` color overrides
+// (see src/mapgl/README.md-style rationale: it's a CSS-custom-property theme, not a
+// Sass module we can reconfigure), so the equivalent override is done via the
+// --bulma-link-* custom properties instead. Values confirmed against
+// node_modules/bulma/{sass/utilities/initial-variables.sass (0.7.5, via `npm pack`),
+// css/versions/bulma-no-dark-mode.css (1.0.4)}.
+:root {
+  --bulma-link-h: 217deg;
+  --bulma-link-s: 71%;
+  --bulma-link-l: 53%;
+  --bulma-link-on-scheme-l: 53%;
+  // Bulma 0.7.5's default $red (is-danger) was hsl(348, 100%, 61%); Bulma 1.0's default
+  // --bulma-danger-l is 70%, which is what made the Clear button (type="is-danger")
+  // look different after the migration. Hue/saturation already match (348deg/100%).
+  --bulma-danger-l: 61%;
+}
+
 $fp-enable-1x1: false;
 $fp-4x3-path: "../node_modules/flagpack/flags/4x3/";
 

--- a/src/assets/global.css
+++ b/src/assets/global.css
@@ -30,6 +30,30 @@
 .th-wrap .is-invisible {
   display: none;
 }
+
+/* Bulma/Buefy 3 fix: .th-wrap is display:flex but sized to its text content only
+   (width:auto), while its .sort-icon child is position:absolute (Buefy's own
+   _table.scss puts it at right:0/bottom:50%, or left:0 for .is-numeric columns) and
+   thus doesn't participate in that width calculation. The icon ends up positioned
+   right against (overlapping) the header text instead of after it. Reserve space for
+   the absolutely-positioned icon with padding on the side it's anchored to. */
+.th-wrap {
+  padding-right: 1.5rem;
+}
+.th-wrap.is-numeric {
+  padding-right: 0;
+  padding-left: 1.5rem;
+}
+
+/* Bulma 1.0 fix: Buefy renders buttons as <button class="button control is-small">.
+   .button.is-small only overrides the --bulma-control-size custom property; the actual
+   font-size declaration lives on the bare .button selector. Bulma's own .control rule
+   (same 0,1,0 specificity, but later in the stylesheet) sets font-size directly to
+   --bulma-size-normal, which wins and makes every is-small/is-medium/is-large button
+   render at the normal size regardless of the size modifier. */
+.button.control {
+  font-size: var(--bulma-control-size);
+}
 .message-body .icon svg {
   height: 2.5rem;
 }

--- a/src/components/ActivationsList.vue
+++ b/src/components/ActivationsList.vue
@@ -9,11 +9,11 @@
       <b-table-column field="date" label="Date" sortable v-slot="props">
         {{ formatActivationDate(props.row.date) }}
       </b-table-column>
-      <b-table-column field="summit.code" label="Summit" class="code" sortable v-slot="props">
+      <b-table-column field="summit.code" label="Summit" cell-class="code" sortable v-slot="props">
         <CountryFlag v-if="props.row.summit.isoCode" :country="props.row.summit.isoCode" class="flag" />
         <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
       </b-table-column>
-      <b-table-column field="summit.name" label="Name" class="name" sortable v-slot="props">
+      <b-table-column field="summit.name" label="Name" cell-class="name" sortable v-slot="props">
         <router-link :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.name }}</router-link>
         <font-awesome-icon v-if="hasOwnPhotos(props.row.summit)" class="photos-icon" :icon="['far', 'images']" />
         <font-awesome-icon v-else-if="props.row.summit.photoAuthors && props.row.summit.photoAuthors.length > 0" class="photos-icon-others" :icon="['far', 'images']" />
@@ -132,7 +132,10 @@ export default {
   margin-left: 0.5em;
   color: #aaa;
 }
-.invalid .code, .invalid .name {
+/* :deep() is required because <tr>/<td> are rendered by Buefy's <b-table>, not by
+   this component's template, so Vue's scoped-CSS data-v-* attribute is never applied
+   to them (only to elements written directly in the v-slot content). */
+:deep(.invalid .code), :deep(.invalid .name) {
   opacity: 0.7;
   text-decoration: line-through;
 }

--- a/src/components/AlertsList.vue
+++ b/src/components/AlertsList.vue
@@ -18,7 +18,7 @@
     </CardPagination>
     <p v-else-if="!$mq.desktop && cardAlerts.length === 0">No matching alerts found.</p>
     <b-table v-else default-sort="dateActivated" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" v-model:current-page="curPage" :row-class="rowClass">
-      <b-table-column field="dateActivated" class="timestamp" label="Date/Time" sortable v-slot="props">
+      <b-table-column field="dateActivated" cell-class="timestamp" label="Date/Time" sortable v-slot="props">
         <span v-html="formatDateTimeRelative(props.row.dateActivated)" />
       </b-table-column>
       <b-table-column v-if="showCallsign" field="activatorCallsign" label="Callsign" sortable v-slot="props">
@@ -29,7 +29,7 @@
           {{ props.row.activatorCallsign }}
         </template>
       </b-table-column>
-      <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." class="nowrap" sortable v-slot="props">
+      <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." cell-class="nowrap" sortable v-slot="props">
         <CountryFlag v-if="props.row.summit.isoCode && $mq.fullhd" :country="props.row.summit.isoCode" class="flag" />
         <router-link v-if="props.row.summit.name" :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
         <span v-else>{{ props.row.summit.code }}</span>
@@ -227,7 +227,12 @@ export default {
 
 <style scoped>
 @media (min-width: 769px) {
-  .table .comments {
+  /* Targeting the .comments-cell element directly (rather than the .comments class
+     passed to <b-table-column>) because Buefy 3's table rendering no longer forwards
+     that class onto the rendered <td> (only a data-label attribute is), unlike
+     Buefy 0.8. SpotsList.vue's equivalent column doesn't have this problem because it
+     already targets .comments-tooltip, a real rendered element. */
+  .comments-cell {
     font-size: 0.8rem;
     max-width: 30em;
   }

--- a/src/components/EditAlert.vue
+++ b/src/components/EditAlert.vue
@@ -351,7 +351,7 @@ export default {
       time: '',
       freqMode: [],
       freqModeSuggestions: [],
-      freqModeConfirmKeys: [',', 'Tab', 'Enter', ' '],
+      freqModeConfirmKeys: ['Tab', 'Enter'],
       comments: '',
       summit: null,
       summitInvalid: false,

--- a/src/components/EditSpot.vue
+++ b/src/components/EditSpot.vue
@@ -30,9 +30,12 @@
       </b-field>
 
       <b-field label="Mode">
-        <b-field>
+        <!-- plain markup instead of nested <b-field>: Vue 3 compiles v-for into a single
+             Fragment vnode, so BField's hasAddons() (which counts rendered vnodes) sees one
+             node instead of many and never adds has-addons -->
+        <div class="field has-addons">
           <b-radio-button v-for="(curModeDisp, curMode) in allModes()" :key="curMode" v-model="mode" :size="$mq.mobile ? 'is-small' : ''" :native-value="curMode" :disabled="type !== 'NORMAL'">{{ curModeDisp }}</b-radio-button>
-        </b-field>
+        </div>
       </b-field>
 
       <b-field label="Comments">

--- a/src/components/MapFilterControl.vue
+++ b/src/components/MapFilterControl.vue
@@ -384,6 +384,15 @@ export default {
   float: right;
   margin-left: 0.5em;
   margin-top: 0.2em;
+  /* Bulma 1.0 moved the .button background-color declaration onto the bare .button
+     selector (specificity 0,1,0) and left .button.is-link/.is-danger only overriding
+     CSS custom properties. That's lower specificity than maplibre-gl's
+     ".maplibregl-ctrl-group button { background-color: transparent }" (0,1,1), which
+     wins and makes Update/Clear render with no fill. Re-declare using the same custom
+     properties so is-link/is-danger colors (including the App.vue :root override) still apply. */
+  background-color: hsl(var(--bulma-button-h), var(--bulma-button-s), var(--bulma-button-background-l));
+  color: hsl(var(--bulma-button-h), var(--bulma-button-s), var(--bulma-button-color-l));
+  border-color: hsl(var(--bulma-button-h), var(--bulma-button-s), var(--bulma-button-border-l));
 }
 .maplibre-gl-filter-container .filter-container {
   display: none;

--- a/src/components/QSOList.vue
+++ b/src/components/QSOList.vue
@@ -1,19 +1,19 @@
 <template>
   <b-table class="auto-width" :narrowed="true" :striped="true" :data="data" :mobile-cards="false">
-    <b-table-column field="TimeOfDay" label="Time" class="nowrap" sortable v-slot="props">
+    <b-table-column field="TimeOfDay" label="Time" cell-class="nowrap" sortable v-slot="props">
       {{ props.row.TimeOfDay }}
     </b-table-column>
-    <b-table-column field="OtherCallsign" label="Callsign" class="nowrap" sortable v-slot="props">
+    <b-table-column field="OtherCallsign" label="Callsign" cell-class="nowrap" sortable v-slot="props">
       <CountryFlag :country="isoCodeForCallsign(props.row.OtherCallsign.trim())" class="flag" />
       <router-link :to="makeActivatorLink(props.row.OtherCallsign.trim())">{{ props.row.OtherCallsign.trim() }}</router-link>
     </b-table-column>
-    <b-table-column field="Band" label="Band" :custom-sort="sortBand" class="nowrap" sortable numeric v-slot="props">
+    <b-table-column field="Band" label="Band" :custom-sort="sortBand" cell-class="nowrap" sortable numeric v-slot="props">
       {{ bandForDbFrequency(props.row.Band) }}
     </b-table-column>
-    <b-table-column field="Mode" label="Mode" class="mode nowrap" sortable v-slot="props">
+    <b-table-column field="Mode" label="Mode" cell-class="mode nowrap" sortable v-slot="props">
       <ModeLabel :mode="props.row.Mode" />
     </b-table-column>
-    <b-table-column field="Notes" label="Notes" class="nowrap" v-slot="props">
+    <b-table-column field="Notes" label="Notes" cell-class="nowrap" v-slot="props">
       <span v-html="formatNotes(props.row.Notes)" />
     </b-table-column>
   </b-table>
@@ -67,7 +67,10 @@ export default {
 .flag {
   margin-right: 0.4em;
 }
-.mode .tag {
+/* :deep() is required because <td> is rendered by Buefy's <b-table>, not by this
+   component's template, so Vue's scoped-CSS data-v-* attribute is never applied to
+   it (only to elements written directly in the v-slot content). */
+:deep(.mode .tag) {
   padding-top: 0.3em;
   padding-bottom: 0.3em;
 }

--- a/src/components/RBNSpotsList.vue
+++ b/src/components/RBNSpotsList.vue
@@ -5,7 +5,7 @@
     </template>
   </CardPagination>
   <b-table v-else :default-sort="['timeStamp', 'desc']" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" :row-class="rowClass">
-    <b-table-column field="timeStamp" class="timestamp" label="Time" sortable v-slot="props">
+    <b-table-column field="timeStamp" cell-class="timestamp" label="Time" sortable v-slot="props">
       <span v-html="formatTimeDay(props.row.timeStamp)" />
     </b-table-column>
     <b-table-column field="callsign" label="Callsign" sortable v-slot="props">
@@ -100,13 +100,16 @@ export default {
 </script>
 
 <style scoped>
-tr .timestamp {
+/* :deep() is required because <tr>/<td> are rendered by Buefy's <b-table>, not by
+   this component's template, so Vue's scoped-CSS data-v-* attribute is never applied
+   to them (only to elements written directly in the v-slot content). */
+:deep(tr .timestamp) {
   border-left: 3px solid #e0e0e0;
 }
-tr.recent1 .timestamp {
+:deep(tr.recent1 .timestamp) {
   border-left: 3px solid #f28591;
 }
-tr.recent2 .timestamp {
+:deep(tr.recent2 .timestamp) {
   border-left: 3px solid #fbaf63;
 }
 .card {

--- a/src/components/SpotsList.vue
+++ b/src/components/SpotsList.vue
@@ -14,7 +14,7 @@
       </template>
     </CardPagination>
     <b-table v-else :default-sort="['timeStamp', 'desc']" :narrowed="true" :striped="true" :data="data" :paginated="paginated" :per-page="perPage" v-model:current-page="curPage" :row-class="rowClass">
-      <b-table-column field="timeStamp" class="timestamp" label="Time" sortable v-slot="props">
+      <b-table-column field="timeStamp" cell-class="timestamp" label="Time" sortable v-slot="props">
         <span v-html="formatTimeDay(props.row.timeStamp)" />
       </b-table-column>
       <b-table-column v-if="showCallsign" field="activatorCallsign" label="Callsign" sortable v-slot="props">
@@ -31,7 +31,7 @@
       <b-table-column field="mode" label="Mode" sortable v-slot="props">
         <ModeLabel :mode="props.row.mode" :type="props.row.type" />
       </b-table-column>
-      <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." class="nowrap" sortable v-slot="props">
+      <b-table-column v-if="showSummitInfo" field="summit.code" label="Summit Ref." cell-class="nowrap" sortable v-slot="props">
         <CountryFlag v-if="props.row.summit.isoCode && $mq.fullhd" :country="props.row.summit.isoCode" class="flag" />
         <router-link v-if="props.row.summit.name" :to="makeSummitLink(props.row.summit.code)">{{ props.row.summit.code }}</router-link>
         <span v-else>{{ props.row.summit.code }}</span>
@@ -217,13 +217,16 @@ export default {
 </script>
 
 <style scoped>
-tr .timestamp {
+/* :deep() is required because <tr>/<td> are rendered by Buefy's <b-table>, not by
+   this component's template, so Vue's scoped-CSS data-v-* attribute is never applied
+   to them (only to elements written directly in the v-slot content). */
+:deep(tr .timestamp) {
   border-left: 3px solid #e0e0e0;
 }
-tr.recent1 .timestamp {
+:deep(tr.recent1 .timestamp) {
   border-left: 3px solid #f28591;
 }
-tr.recent2 .timestamp {
+:deep(tr.recent2 .timestamp) {
   border-left: 3px solid #fbaf63;
 }
 @media (min-width: 769px) {

--- a/src/components/SummitList.vue
+++ b/src/components/SummitList.vue
@@ -1,19 +1,19 @@
 <template>
   <b-table :class="{ 'auto-width': autoWidth, summits: true }" default-sort="code" :narrowed="true" :striped="true" :data="data" :mobile-cards="false" :row-class="(row, index) => !row.isValid && 'is-invalid'">
-    <b-table-column field="code" label="Reference" class="nowrap" sortable v-slot="props">
+    <b-table-column field="code" label="Reference" cell-class="nowrap" sortable v-slot="props">
       <router-link :to="makeSummitLink(props.row.code)">{{ props.row.code }}</router-link>
     </b-table-column>
-    <b-table-column field="name" label="Name" class="summit-name" sortable v-slot="props">
+    <b-table-column field="name" label="Name" cell-class="summit-name" sortable v-slot="props">
       <router-link :to="makeSummitLink(props.row.code)">{{ props.row.name }}</router-link>
       <font-awesome-icon v-if="props.row.hasPhotos" class="photos-icon" :icon="['far', 'images']" />
     </b-table-column>
-    <b-table-column field="altitude" :label="$mq.mobile ? 'Alt.' : 'Altitude'" class="nowrap" sortable numeric v-slot="props">
+    <b-table-column field="altitude" :label="$mq.mobile ? 'Alt.' : 'Altitude'" cell-class="nowrap" sortable numeric v-slot="props">
       <AltitudeLabel :altitude="props.row.altitude" />
     </b-table-column>
-    <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" class="nowrap" sortable v-slot="props">
+    <b-table-column field="points" :label="$mq.mobile ? 'Pts.' : 'Points'" cell-class="nowrap" sortable v-slot="props">
       <SummitPointsLabel :points="props.row.points" :bonus="$mq.mobile ? null : props.row.bonusPoints" class="points" />
     </b-table-column>
-    <b-table-column field="activationCount" :label="$mq.mobile ? 'Act.' : 'Activations'" class="nowrap" sortable numeric v-slot="props">
+    <b-table-column field="activationCount" :label="$mq.mobile ? 'Act.' : 'Activations'" cell-class="nowrap" sortable numeric v-slot="props">
       {{ props.row.activationCount }}
       <font-awesome-icon v-if="myActivatedSummits" :icon="activationIcon(props.row)" :class="activationIconClass(props.row)" :label="activationIconLabel(props.row)" :title="activationIconLabel(props.row)" />
       <font-awesome-icon v-if="myActivatedSummitsThisYear" :icon="['far', 'calendar-check']" :class="calendarIconClass(props.row)" :label="calendarIconLabel(props.row)" :title="calendarIconLabel(props.row)" />
@@ -128,8 +128,11 @@ export default {
 .summits :deep(.is-invalid) {
   opacity: 0.5;
 }
+/* :deep() is required because <table>/<td> are rendered by Buefy's <b-table>, not by
+   this component's template, so Vue's scoped-CSS data-v-* attribute is never applied
+   to them (only to elements written directly in the v-slot content). */
 @media (max-width: 414px) {
-  .table .summit-name {
+  :deep(.table .summit-name) {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -137,10 +140,10 @@ export default {
   }
 }
 @media (max-width: 375px) {
-  .table td, .table th {
+  :deep(.table td), :deep(.table th) {
     padding: 0.25em 0.3em;
   }
-  .table .summit-name {
+  :deep(.table .summit-name) {
     max-width: 8em;
   }
 }

--- a/src/views/Activators.vue
+++ b/src/views/Activators.vue
@@ -10,7 +10,7 @@
           </b-field>
 
           <b-table class="auto-width" :narrowed="true" :striped="true" :data="activators" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" v-model:current-page="curPage" backend-sorting :default-sort="[sortField, sortDirection]" @sort="onSort" :mobile-cards="false">
-            <b-table-column field="callsign" label="Callsign" class="nowrap" sortable v-slot="props">
+            <b-table-column field="callsign" label="Callsign" cell-class="nowrap" sortable v-slot="props">
               <CountryFlag :country="country(props.row.callsign)" class="flag" />
               <router-link :to="makeActivatorLink(props.row.callsign)">{{ props.row.callsign }}</router-link>
             </b-table-column>

--- a/src/views/Association.vue
+++ b/src/views/Association.vue
@@ -16,7 +16,7 @@
         <div class="columns">
           <div class="column">
             <b-table default-sort="code" :narrowed="true" :striped="true" :data="filteredRegions" :mobile-cards="false">
-              <b-table-column field="code" label="Identifier" class="nowrap" sortable v-slot="props">
+              <b-table-column field="code" label="Identifier" cell-class="nowrap" sortable v-slot="props">
                 <router-link :to="regionLink(props.row)">{{ props.row.code }}</router-link>
               </b-table-column>
               <b-table-column field="name" label="Name" sortable v-slot="props">

--- a/src/views/AssociationList.vue
+++ b/src/views/AssociationList.vue
@@ -12,7 +12,7 @@
           <FilterInput v-model="filter" ref="filter" />
         </b-field>
         <b-table class="auto-width" default-sort="code" :narrowed="true" :striped="true" :data="filteredAssociations" :mobile-cards="false">
-          <b-table-column field="code" label="Identifier" class="nowrap" sortable v-slot="props">
+          <b-table-column field="code" label="Identifier" cell-class="nowrap" sortable v-slot="props">
             <router-link :to="associationLink(props.row)">{{ props.row.code }}</router-link>
           </b-table-column>
           <b-table-column field="name" label="Name" sortable v-slot="props">


### PR DESCRIPTION
## Summary

This PR fixes 5 regressions introduced by the Vue 2 → Vue 3 / Buefy 3 / Bulma 1.0 migration
(`vue3` branch) — 4 reported by @manuelkasper as visual regressions, plus one we found and
reported ourselves earlier.

1. **Link/danger colors reverted to Bulma defaults** — the pre-migration `$link`/`$red` Sass
   overrides don't apply under Bulma 1.0's CSS-custom-property theme (the `bulma-no-dark-mode`
   entry point doesn't support Sass `with()` overrides). Also fixes the map filter Update/Clear
   buttons rendering with no background fill at all (a CSS-specificity regression against
   maplibre-gl's own button styles).
2. **Button sizing (`is-small` etc.) and table sort-icon spacing** — two Bulma 1.0
   CSS-specificity regressions: `.control`'s font-size declaration now wins over
   `.is-small`/`.is-medium`/`.is-large`, and the table sort icon (`position: absolute`) overlaps
   header text because `.th-wrap` doesn't reserve space for it.
3. **`<b-table-column class="...">` no longer reaches `<td>`** — Buefy 3 splits `class` (header
   only) from the new `cell-class` prop (cell). Converted across 9 files, plus fixed 5 files'
   scoped styles that target `<tr>`/`<td>` directly (Vue never applies a component's scoped
   `data-v-*` attribute to elements rendered by a child component like `<b-table>`).
4. **Add Spot mode-selector buttons stack vertically instead of forming a joined row** — Vue 3
   compiles `v-for` into a single Fragment vnode, so Buefy's addon-detection (`hasAddons()`)
   undercounts rendered nodes and never applies the `has-addons` class.
5. **EditAlert taginput loses text on fast comma/space bulk entry** — found and reported by us
   earlier while verifying the migration, now root-caused: Buefy 3's `Taginput.addTag()` defers
   clearing `newTag` until the next animation frame, which raced with the parent's per-comma
   confirm-key handler during fast typing.

## Verification

Each fix was verified live in a container (headless Chromium via Playwright, dev-only Turnstile
bypass) against the deployed vue3 preview, comparing against Vue 2 production (sotl.as) where
applicable. See individual commit messages for the specific measurements (computed colors,
bounding-rect coordinates, etc.) used to confirm each fix.
