### PR TITLE
Fix two bugs that turned out to be pre-existing on Vue 2, not migration regressions

### DIFF
--- a/src/components/MapFilterControl.vue
+++ b/src/components/MapFilterControl.vue
@@ -223,6 +223,13 @@ export default {
           this.setSummitFilter(null)
           this.active = false
         }
+      }).catch(() => {
+        this.filterLoadingCount = 0
+        this.$buefy.snackbar.open({
+          message: 'SOTA database error, try again later',
+          type: 'is-warning',
+          position: 'is-bottom'
+        })
       })
     },
     setActivations (from, to) {
@@ -379,6 +386,9 @@ export default {
 .filter-criterion button {
   border: 1px solid #dbdbdb;
   background-color: #fff;
+}
+.action-buttons {
+  overflow: hidden; /* clearfix: the floated buttons below would otherwise collapse this row's height */
 }
 .action-buttons button {
   float: right;

--- a/src/components/MapOptionsControl.vue
+++ b/src/components/MapOptionsControl.vue
@@ -308,6 +308,6 @@ export default {
   vertical-align: bottom;
 }
 .b-tooltip {
-  vertical-align: bottom;
+  vertical-align: top;
 }
 </style>


### PR DESCRIPTION
## Summary

Two items that turned out not to be Vue 3 migration regressions, despite looking like ones:

1. **Map options panel icon slides down when opened** — this was on the original regression
   list as a Vue 3 issue, but it reproduces identically on current `master` (Vue 2) today, so it
   predates the migration. The icon and panel share a CSS line box; `.b-tooltip
   { vertical-align: bottom }` pins the icon to the bottom of that box once the panel grows it.
   Switched to `vertical-align: top`.
2. **Map filter Update button gets stuck loading on error, and filter panel buttons render
   outside the panel background** — found during Phase 3 migration verification and flagged
   then as pre-existing on Vue 2; submitting now as promised. `updateFilter()`'s `Promise.all()`
   had no `.catch()`, so a failed candidate-filter request left `filterLoadingCount` stuck above
   zero. Separately, `.action-buttons`'s floated buttons collapsed the row to zero height
   without a clearfix, pushing the buttons outside the panel.

## Verification

Verified live in a container (headless Chromium via Playwright, dev-only Turnstile bypass)
against the deployed vue3 preview. See individual commit messages for the specific
before/after measurements.