### PR TITLE
docs: fix stale npm script instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ before running `npm install` and the Pro icons will be installed and used as nor
 
 ### Compiles and hot-reloads for development
 ```
-npm run serve
+npm run dev
 ```
 
 ### Compiles and minifies for production
@@ -26,15 +26,10 @@ npm run serve
 npm run build
 ```
 
-### Run your tests
-```
-npm run test
-```
-
-### Lints and fixes files
+### Lints files
 ```
 npm run lint
 ```
 
 ### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+See [Vite Configuration Reference](https://vite.dev/config/).


### PR DESCRIPTION
## Summary

The dev workflow section still described the pre-Vite (Vue CLI) setup:

- `npm run serve` no longer starts a dev server — it now runs `vite preview` (a production-build
  preview). The dev server is `npm run dev`.
- The "Run your tests" section referenced a `test` script that doesn't exist.
- "Customize configuration" pointed at the Vue CLI config docs instead of Vite's.

This predates the Vue 3 migration — the same staleness exists on `master` — so it's a small,
standalone doc-only fix, unrelated to the migration work.

## Verification

Confirmed against `package.json`'s actual `scripts` entries (`dev`, `build`, `lint`, `serve`);
no code changes, so no lint/build impact.